### PR TITLE
docs: update README for Phase 4 completion and voice model setup #6 #…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,30 @@
 # Aria — Personal AI Desktop Assistant
 
-An autonomous AI desktop assistant with a chibi anime avatar, British voice,
+An autonomous AI desktop assistant with a chibi anime avatar, natural voice,
 persistent memory, and live web access. Built in Python on Windows 11.
 
 ## Features
-- 🎙️ Wake word activation — "Hey Aria"
-- 🧠 Powered by Anthropic Claude API (with local model migration path)
-- 🗣️ Coqui TTS — mature British female voice
-- 🖥️ Chibi sprite avatar — desktop overlay, bottom right corner
-- 💾 Persistent memory — SQLite + JSON
-- 🌐 Live web scraping — weather and more
-- 📅 Scheduling and reminders
-- 📊 Claude API usage tracking
+- Wake word activation — "Hey Aria"
+- Powered by Anthropic Claude API (with local Ollama fallback)
+- Piper TTS — hfc_female medium voice (local ONNX inference)
+- Chibi sprite avatar — desktop overlay with Win32 transparency
+- Persistent memory — SQLite episodic + semantic
+- Live web scraping — weather via Playwright/httpx
+- Scheduling and reminders via APScheduler
+- Voice recognition training with WER scoring
+
+## Phase Status
+
+| Phase | Feature | Status |
+|-------|---------|--------|
+| 1 | Voice pipeline (Whisper) | Complete |
+| 2 | Claude brain + memory | Complete |
+| 3 | Piper TTS voice output | Complete |
+| 4 | Live web scraping — weather | Complete |
+| 5 | Sprite avatar system | Complete |
+| 6 | Voice recognition training | Planned |
+| 7 | Intent router | Planned |
+| 8 | Wake word polish + animations | Planned |
 
 ## Setup
 
@@ -30,15 +43,26 @@ venv\Scripts\activate
 ### 3. Install dependencies
 ```
 pip install -r requirements.txt
+playwright install chromium
 ```
 
-### 4. Configure API keys
+### 4. Download voice model
+Download the Piper hfc_female medium ONNX model from HuggingFace:
+```
+mkdir assets\voices
+curl -L -o assets/voices/en_US-hfc_female-medium.onnx ^
+  "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/hfc_female/medium/en_US-hfc_female-medium.onnx"
+curl -L -o assets/voices/en_US-hfc_female-medium.onnx.json ^
+  "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/hfc_female/medium/en_US-hfc_female-medium.onnx.json"
+```
+
+### 5. Configure API keys
 ```
 cp config.example.py config.py
-# Edit config.py and add your API keys
+# Edit config.py and add your Anthropic API key
 ```
 
-### 5. Run
+### 6. Run
 ```
 python main.py
 ```
@@ -46,41 +70,47 @@ python main.py
 ## Project Structure
 ```
 aria/
-├── main.py
+├── main.py                # Entry point — avatar + voice pipeline
 ├── config.py              # Not committed — contains API keys
 ├── config.example.py      # Safe template
 ├── core/
-│   ├── brain.py           # Claude API + intent routing
+│   ├── brain.py           # Claude API + local intent routing
 │   ├── memory.py          # SQLite persistent memory
 │   ├── scheduler.py       # APScheduler reminders
 │   ├── personality.py     # Aria's evolving personality
-│   ├── router.py          # Intent classification
-│   └── usage_tracker.py   # Claude API usage logging
+│   └── web_search.py      # Playwright web scraping (weather + more)
 ├── voice/
-│   ├── listener.py        # Wake word + microphone
-│   ├── transcriber.py     # Whisper speech-to-text
-│   ├── speaker.py         # Coqui TTS voice output
-│   └── trainer.py         # Voice recognition training
+│   ├── listener.py        # Microphone capture + silence detection
+│   ├── transcriber.py     # Whisper speech-to-text (CUDA)
+│   ├── speaker.py         # Piper TTS voice output + lip-sync
+│   ├── wake.py            # Wake word detection (local Whisper)
+│   ├── trainer.py         # Voice recognition training + WER
+│   └── chime.py           # Wake notification sound
 ├── avatar/
-│   ├── renderer.py        # Pygame sprite renderer
-│   ├── animations.py      # Sleep, wake, talk, blink
-│   └── window.py          # Transparent desktop overlay
+│   ├── renderer.py        # High-level avatar state API
+│   ├── animations.py      # Tick-based animation system
+│   └── window.py          # Win32 transparent desktop overlay
+├── tools/
+│   └── generate_sprites.py # Procedural sprite generation (Pillow)
 ├── assets/
-│   └── sprites/           # Aria expression sprites
+│   ├── sprites/           # Aria expression sprites (6 states)
+│   ├── voices/            # Piper ONNX voice models (gitignored)
+│   └── sounds/            # Generated audio files (gitignored)
 └── data/                  # Local data — not committed
 ```
 
 ## Tech Stack
 | Component | Technology |
 |-----------|-----------|
-| AI Brain | Anthropic Claude API |
-| Wake Word | Picovoice Porcupine |
-| Voice Input | faster-whisper |
-| Voice Output | Coqui TTS |
-| Avatar | Pygame sprite system |
-| Memory | SQLite + JSON |
-| Scheduler | APScheduler |
-| Web Access | Playwright |
+| AI Brain | Anthropic Claude API (Haiku + Sonnet) |
+| Local Fallback | Ollama |
+| Voice Input | faster-whisper (CUDA) |
+| Voice Output | Piper TTS (hfc_female medium) |
+| Wake Word | Whisper keyword spotting (no API keys) |
+| Avatar | Pygame sprite system + Win32 overlay |
+| Memory | SQLite (episodic + semantic) + JSON |
+| Scheduler | APScheduler + SQLAlchemy |
+| Web Scraping | Playwright + httpx |
 
 ## Author
 Chanveer Grewal — github.com/chansg


### PR DESCRIPTION
…7 #8

- Add phase status table showing Phases 1-5 complete
- Add voice model download instructions (hfc_female medium)
- Add playwright install chromium as setup step
- Update project structure to reflect current files
- Update tech stack table (Piper TTS, Whisper wake word, web scraping)
- Remove references to Coqui TTS and Picovoice (no longer used)