### PR TITLE
feat: improve speech accuracy — Whisper large-v2, VAD, initial prompt…

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,7 +38,12 @@ from avatar.renderer import (
 from voice.trainer import run_calibration, get_profile_summary
 
 # Name variants Whisper might produce (case-insensitive matching)
-ARIA_VARIANTS = {"aria", "arya", "area", "ariya", "ariia"}
+# Expanded for large-v2 + British accent phonetic variants
+ARIA_VARIANTS = {
+    "aria", "arya", "area", "ariya", "ariia",
+    "ari", "ariah", "aeria", "era", "aaria",
+    "harry", "maria",  # Common misheard variants
+}
 
 # ── Conversation mode flag ─────────────────────────────────────────
 # ON (set)  = always-listening conversation mode

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,10 @@
 # Environment / config
 python-dotenv>=1.0.0
 
-# Audio capture
+# Audio capture + preprocessing
 PyAudio>=0.2.14
 numpy>=1.24.0
+noisereduce>=3.0.0
 
 # Speech-to-text (local, GPU-accelerated)
 faster-whisper>=1.0.0

--- a/voice/listener.py
+++ b/voice/listener.py
@@ -7,6 +7,7 @@ then returns the raw audio data for transcription.
 """
 
 import numpy as np
+import noisereduce as nr
 import pyaudio
 import wave
 import io
@@ -107,6 +108,33 @@ def is_silent(audio_chunk: bytes) -> bool:
     return rms < _silence_threshold
 
 
+def preprocess_audio(audio_bytes: bytes) -> bytes:
+    """Apply noise reduction to raw audio before transcription.
+
+    Reduces background noise and improves Whisper accuracy in home
+    environments. Uses a stationary noise estimation approach.
+
+    Args:
+        audio_bytes: Raw 16-bit PCM audio bytes.
+
+    Returns:
+        Noise-reduced audio as raw bytes.
+    """
+    try:
+        audio_data = np.frombuffer(audio_bytes, dtype=np.int16).astype(np.float32)
+        reduced = nr.reduce_noise(
+            y=audio_data,
+            sr=SAMPLE_RATE,
+            stationary=True,
+            prop_decrease=0.75,
+        )
+        print("[Aria] Noise reduction applied.")
+        return reduced.astype(np.int16).tobytes()
+    except Exception as e:
+        print(f"[Aria] WARNING: Noise reduction failed ({e}), using raw audio.")
+        return audio_bytes
+
+
 def record_audio(device_index: int = None) -> bytes:
     """Record audio from the microphone until silence is detected.
 
@@ -190,7 +218,8 @@ def record_audio(device_index: int = None) -> bytes:
         print(f"[Aria] Too short ({duration:.1f}s < {MIN_RECORDING_DURATION}s) — ignoring.")
         return b""
 
-    return raw_audio
+    # Apply noise reduction before returning
+    return preprocess_audio(raw_audio)
 
 
 def audio_bytes_to_wav(audio_bytes: bytes) -> bytes:

--- a/voice/transcriber.py
+++ b/voice/transcriber.py
@@ -28,6 +28,14 @@ if sys.platform == "win32":
 from faster_whisper import WhisperModel
 from config import WHISPER_MODEL_SIZE, WHISPER_DEVICE, WHISPER_COMPUTE_TYPE, SAMPLE_RATE, TRANSCRIPTION_TIMEOUT
 
+# Biases Whisper transcription toward Aria's expected vocabulary.
+# Include the name variants and common command words Chan uses.
+WHISPER_INITIAL_PROMPT = (
+    "Aria, hey Aria, weather, temperature, reminder, schedule, "
+    "appointment, time, date, what's, tell me, can you, please, "
+    "Birmingham, morning, evening, today, tomorrow"
+)
+
 # Module-level model instance (loaded once, reused)
 _model: WhisperModel = None
 
@@ -82,6 +90,11 @@ def transcribe_audio(audio_bytes: bytes) -> str:
                 beam_size=5,
                 language="en",
                 vad_filter=True,
+                vad_parameters=dict(
+                    min_silence_duration_ms=500,
+                    speech_pad_ms=200,
+                ),
+                initial_prompt=WHISPER_INITIAL_PROMPT,
             )
         except Exception as e:
             print(f"[Aria] Whisper error: {e}")


### PR DESCRIPTION
…, noisereduce #13

- Upgrade Whisper model from base to large-v2 for RTX 3080
- Add VAD parameters (500ms min silence, 200ms speech pad)
- Add WHISPER_INITIAL_PROMPT biasing toward Aria vocabulary
- Add noisereduce preprocessing (stationary, 75% reduction)
- Expand ARIA_VARIANTS with British accent phonetic variants
- Add noisereduce>=3.0.0 to requirements.txt