### PR TITLE
feat: add intent router + Ollama integration — three-tier dispatch #1…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ persistent memory, and live web access. Built in Python on Windows 11.
 
 ## Features
 - Wake word activation — "Hey Aria"
-- Powered by Anthropic Claude API (with local Ollama fallback)
+- Three-tier intent routing — local, web+Ollama, Claude API
 - Piper TTS — hfc_female medium voice (local ONNX inference)
 - Chibi sprite avatar — desktop overlay with Win32 transparency
 - Persistent memory — SQLite episodic + semantic
-- Live web scraping — weather via Playwright/httpx
+- DuckDuckGo web scraping + Ollama local reasoning (Tier 2)
 - Scheduling and reminders via APScheduler
 - Voice recognition training with WER scoring
 
@@ -22,8 +22,8 @@ persistent memory, and live web access. Built in Python on Windows 11.
 | 3 | Piper TTS voice output | Complete |
 | 4 | Live web scraping — weather | Complete |
 | 5 | Sprite avatar system | Complete |
-| 6 | Voice recognition training | Planned |
-| 7 | Intent router | Planned |
+| 6 | Voice recognition training | Complete |
+| 7 | Intent router + Ollama integration | Complete |
 | 8 | Wake word polish + animations | Planned |
 
 ## Setup
@@ -74,11 +74,12 @@ aria/
 ├── config.py              # Not committed — contains API keys
 ├── config.example.py      # Safe template
 ├── core/
-│   ├── brain.py           # Claude API + local intent routing
+│   ├── brain.py           # Tier dispatcher — routes to handler
+│   ├── router.py          # Intent classification (single source of truth)
 │   ├── memory.py          # SQLite persistent memory
 │   ├── scheduler.py       # APScheduler reminders
 │   ├── personality.py     # Aria's evolving personality
-│   └── web_search.py      # Playwright web scraping (weather + more)
+│   └── web_search.py      # DuckDuckGo scraping + result caching
 ├── voice/
 │   ├── listener.py        # Microphone capture + silence detection
 │   ├── transcriber.py     # Whisper speech-to-text (CUDA)
@@ -102,15 +103,16 @@ aria/
 ## Tech Stack
 | Component | Technology |
 |-----------|-----------|
-| AI Brain | Anthropic Claude API (Haiku + Sonnet) |
-| Local Fallback | Ollama |
-| Voice Input | faster-whisper (CUDA) |
+| AI Brain (Tier 3) | Anthropic Claude API (Haiku + Sonnet) |
+| Local Reasoning (Tier 2) | Ollama + DuckDuckGo web scraping |
+| Intent Router | Keyword-based tier classification |
+| Voice Input | faster-whisper large-v2 (CUDA + VAD) |
 | Voice Output | Piper TTS (hfc_female medium) |
 | Wake Word | Whisper keyword spotting (no API keys) |
 | Avatar | Pygame sprite system + Win32 overlay |
 | Memory | SQLite (episodic + semantic) + JSON |
 | Scheduler | APScheduler + SQLAlchemy |
-| Web Scraping | Playwright + httpx |
+| Web Scraping | Playwright + httpx + BeautifulSoup |
 
 ## Author
 Chanveer Grewal — github.com/chansg

--- a/config.example.py
+++ b/config.example.py
@@ -9,6 +9,10 @@ ANTHROPIC_API_KEY = "your-anthropic-api-key-here"
 PICOVOICE_API_KEY = "your-picovoice-api-key-here"
 OPENWEATHER_API_KEY = ""  # Optional — currently using web scraping
 
+# --- Ollama (local LLM for Tier 2 reasoning) ---
+OLLAMA_BASE_URL = "http://localhost:11434"
+OLLAMA_MODEL = "llama3"
+
 # --- Conversation / Prompt Limits ---
 MAX_CONVERSATION_TURNS = 10   # Recent exchanges sent as context to Claude
 MAX_SPEAK_LENGTH = 500        # Max characters per TTS utterance

--- a/core/brain.py
+++ b/core/brain.py
@@ -1,20 +1,29 @@
 """
 Aria Brain Module
 =================
-Handles AI reasoning via Anthropic Claude API or local Ollama model.
-Toggle USE_LOCAL_MODEL in config.py to switch backends.
+Aria's reasoning orchestrator.
 
-Uses Claude tool use to let Aria manage the schedule naturally
-from voice commands.
+All queries are classified by core/router.py first.
+brain.py dispatches to the correct handler based on tier.
+No intent classification logic lives here.
+
+Tier dispatch:
+    Tier 1 — router.py local handlers (time, date, calendar)
+    Tier 2 — web_search.py + Ollama local model reasoning
+    Tier 3 — Claude API for complex open-ended reasoning only
+
+Preserved across all tiers:
+    - Episodic memory (store_episodic) — every exchange is recorded
+    - Personality (record_interaction) — interaction count incremented
+    - Memory context (build_memory_context) — injected into Claude prompts
+    - Scheduler tool use — Claude can manage reminders via tool calls
 """
 
 import json
-import re
 import httpx
 import anthropic
 from datetime import datetime
 from config import (
-    USE_LOCAL_MODEL,
     ANTHROPIC_API_KEY,
     ANTHROPIC_MODEL,
     ANTHROPIC_MODEL_LITE,
@@ -23,80 +32,20 @@ from config import (
     OLLAMA_MODEL,
     MAX_CONVERSATION_TURNS,
 )
+from core.router import classify, handle_time, handle_date, handle_calendar
 from core.personality import get_system_prompt, record_interaction
 from core.memory import store_episodic, build_memory_context
 from core.scheduler import add_reminder, add_reminder_minutes, list_reminders, cancel_reminder
 from core.web_search import search_web
 
 
-# --- Local intent patterns (bypass Claude API entirely) ---
-LOCAL_INTENTS = {
-    "time": {
-        "patterns": [
-            r"\bwhat\s+time\b",
-            r"\bwhat's\s+the\s+time\b",
-            r"\btell\s+me\s+the\s+time\b",
-            r"\bcurrent\s+time\b",
-        ],
-        "handler": lambda _: f"It's {datetime.now().strftime('%H:%M')}, Chan.",
-    },
-    "date": {
-        "patterns": [
-            r"\bwhat\s+date\b",
-            r"\bwhat's\s+the\s+date\b",
-            r"\bwhat\s+day\s+is\s+it\b",
-            r"\btoday's\s+date\b",
-            r"\bcurrent\s+date\b",
-        ],
-        "handler": lambda _: f"It's {datetime.now().strftime('%A, %d %B %Y')}.",
-    },
-    "schedule_check": {
-        "patterns": [
-            r"\bwhat\s+reminders?\b",
-            r"\bshow\s+(my\s+)?reminders?\b",
-            r"\blist\s+(my\s+)?reminders?\b",
-            r"\bmy\s+schedule\b",
-        ],
-        "handler": lambda _: list_reminders(),
-    },
-    "weather": {
-        "patterns": [
-            r"\bweather\b",
-            r"\btemperature\b",
-            r"\bforecast\b",
-            r"\braining\b",
-            r"\bsunny\b",
-            r"\bcloudy\b",
-            r"\bhow\s+(cold|warm|hot)\b",
-            r"\bumbrella\b",
-        ],
-        "handler": lambda _: f"Here's the current weather, Chan: {search_web('weather', location='Birmingham')}",
-    },
-}
+# ── Ollama configuration ──────────────────────────────────────────────────────
+
+OLLAMA_GENERATE_URL = f"{OLLAMA_BASE_URL}/api/generate"
 
 
-def _try_local_intent(user_input: str) -> str | None:
-    """Try to handle the query locally without calling Claude.
+# ── Claude tool definitions for scheduler ─────────────────────────────────────
 
-    Matches user input against LOCAL_INTENTS patterns. If a match
-    is found, runs the handler and returns the response.
-
-    Args:
-        user_input: The user's message.
-
-    Returns:
-        A response string if matched, or None if no local intent fits.
-    """
-    lowered = user_input.lower()
-    for intent in LOCAL_INTENTS.values():
-        for pattern in intent["patterns"]:
-            if re.search(pattern, lowered):
-                print("[Aria] Handled locally — no API call needed.")
-                return intent["handler"](user_input)
-    return None
-
-
-# --- Tool definitions for Claude ---
 TOOLS = [
     {
         "name": "add_reminder_at_time",
@@ -170,6 +119,8 @@ TOOLS = [
 ]
 
 
+# ── Model selection ───────────────────────────────────────────────────────────
+
 def _select_model(user_input: str) -> str:
     """Return the appropriate Claude model based on query complexity.
 
@@ -185,10 +136,12 @@ def _select_model(user_input: str) -> str:
     lowered = user_input.lower()
     word_count = len(lowered.split())
     if word_count > 25 or any(kw in lowered for kw in COMPLEX_QUERY_KEYWORDS):
-        print(f"[Aria] Complex query detected — using {ANTHROPIC_MODEL}")
+        print(f"[Brain] Complex query detected — using {ANTHROPIC_MODEL}")
         return ANTHROPIC_MODEL
     return ANTHROPIC_MODEL_LITE
 
+
+# ── Tool execution ────────────────────────────────────────────────────────────
 
 def _execute_tool(tool_name: str, tool_input: dict) -> str:
     """Execute a tool call from Claude and return the result.
@@ -233,11 +186,16 @@ def _execute_tool(tool_name: str, tool_input: dict) -> str:
     return f"Unknown tool: {tool_name}"
 
 
-def think(user_input: str) -> str:
-    """Process user input and return Aria's response.
+# ── Public entry point ────────────────────────────────────────────────────────
 
-    Routes to either the Claude API or a local Ollama model
-    depending on the USE_LOCAL_MODEL config toggle.
+def think(user_input: str) -> str:
+    """Generate Aria's response using the tiered routing system.
+
+    Classifies the query via router.py, then dispatches to the
+    appropriate handler. Claude is only called for Tier 3 queries.
+
+    Every call stores the exchange in episodic memory and records
+    the interaction for personality evolution.
 
     Args:
         user_input: The transcribed text from the user.
@@ -248,12 +206,118 @@ def think(user_input: str) -> str:
     # Store what the user said
     store_episodic("user", user_input)
 
-    # Try local intent first (no API call needed)
-    local_response = _try_local_intent(user_input)
-    if local_response is not None:
-        store_episodic("aria", local_response)
+    # Classify intent via router
+    route = classify(user_input)
+    tier = route["tier"]
+    intent = route["intent"]
+
+    # ── Tier 1: Local — zero network ─────────────────────────────────────
+    if tier == 1:
+        if intent == "time":
+            response = handle_time()
+        elif intent == "date":
+            response = handle_date()
+        elif intent == "calendar":
+            response = handle_calendar()
+        else:
+            response = handle_time()  # fallback
+
+        store_episodic("aria", response)
         record_interaction()
-        return local_response
+        return response
+
+    # ── Tier 2: Web scrape + Ollama ──────────────────────────────────────
+    if tier == 2:
+        response = _handle_web_query(user_input)
+        store_episodic("aria", response)
+        record_interaction()
+        return response
+
+    # ── Tier 3: Claude API ───────────────────────────────────────────────
+    response = _handle_claude(user_input)
+    store_episodic("aria", response)
+    record_interaction()
+    return response
+
+
+# ── Tier 2 handler ────────────────────────────────────────────────────────────
+
+def _handle_web_query(text: str) -> str:
+    """Handle a Tier 2 query: scrape web, reason with Ollama.
+
+    Falls back to Claude if Ollama is unavailable.
+
+    Args:
+        text: The user's original query.
+
+    Returns:
+        Aria's response based on web-retrieved content.
+    """
+    try:
+        web_context = search_web(text)
+
+        prompt = (
+            "You are Aria, a helpful and concise personal AI assistant. "
+            "Answer the following question using only the web information provided. "
+            "Be brief — 1 to 3 sentences maximum. Address the user as Chan. "
+            "If the web information does not contain a clear answer, say so.\n\n"
+            f"Web information:\n{web_context}\n\n"
+            f"Question: {text}\n\n"
+            "Answer:"
+        )
+
+        return _query_ollama(prompt)
+
+    except Exception as e:
+        print(f"[Brain] Tier 2 failed ({e}) — falling back to Claude.")
+        return _handle_claude(text)
+
+
+def _query_ollama(prompt: str) -> str:
+    """Send a prompt to the local Ollama model and return the response.
+
+    Args:
+        prompt: Full prompt string including any web context.
+
+    Returns:
+        The model's response as a plain string.
+
+    Raises:
+        Exception: If Ollama is not running or returns an error.
+    """
+    response = httpx.post(
+        OLLAMA_GENERATE_URL,
+        json={
+            "model": OLLAMA_MODEL,
+            "prompt": prompt,
+            "stream": False,
+        },
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    result = response.json().get("response", "").strip()
+    if not result:
+        raise ValueError("Ollama returned an empty response.")
+    return result
+
+
+# ── Tier 3 handler ────────────────────────────────────────────────────────────
+
+def _handle_claude(user_input: str) -> str:
+    """Handle a Tier 3 query using the Claude API with tool support.
+
+    Builds the full system prompt with personality and memory context.
+    If Claude decides to use a tool, executes it and sends the result
+    back for a final natural language response.
+
+    Args:
+        user_input: The user's message.
+
+    Returns:
+        Claude's response text.
+    """
+    if not ANTHROPIC_API_KEY:
+        return "I can't think right now — my API key isn't set. Add ANTHROPIC_API_KEY to your .env file, Chan."
 
     # Build the full prompt with memory context
     system_prompt = get_system_prompt()
@@ -266,37 +330,11 @@ def think(user_input: str) -> str:
     now = datetime.now()
     system_prompt += f"\n\nCurrent date and time: {now.strftime('%A %d %B %Y, %H:%M')}."
 
-    # Route to the appropriate backend
-    if USE_LOCAL_MODEL:
-        response = _think_local(system_prompt, user_input)
-    else:
-        response = _think_claude(system_prompt, user_input)
-
-    # Store Aria's response and record the interaction
-    store_episodic("aria", response)
-    record_interaction()
-
-    return response
-
-
-def _think_claude(system_prompt: str, user_input: str) -> str:
-    """Send the prompt to Anthropic's Claude API with tool support.
-
-    If Claude decides to use a tool, executes it and sends the result
-    back for a final natural language response.
-
-    Args:
-        system_prompt: The full system prompt with personality and memory.
-        user_input: The user's message.
-
-    Returns:
-        Claude's response text.
-    """
-    if not ANTHROPIC_API_KEY:
-        return "I can't think right now — my API key isn't set. Add ANTHROPIC_API_KEY to your .env file, Chan."
-
     try:
-        client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY, default_headers={"anthropic-beta": "prompt-caching-2024-07-31"})
+        client = anthropic.Anthropic(
+            api_key=ANTHROPIC_API_KEY,
+            default_headers={"anthropic-beta": "prompt-caching-2024-07-31"},
+        )
         model = _select_model(user_input)
         messages = [{"role": "user", "content": user_input}]
         cached_system = [{"type": "text", "text": system_prompt, "cache_control": {"type": "ephemeral"}}]
@@ -312,15 +350,14 @@ def _think_claude(system_prompt: str, user_input: str) -> str:
 
         # If Claude wants to use a tool, execute it and get a final response
         if response.stop_reason == "tool_use":
-            # Process all tool calls
             tool_results = []
             assistant_content = response.content
 
             for block in assistant_content:
                 if block.type == "tool_use":
-                    print(f"[Aria] Using tool: {block.name}")
+                    print(f"[Brain] Using tool: {block.name}")
                     result = _execute_tool(block.name, block.input)
-                    print(f"[Aria] Tool result: {result}")
+                    print(f"[Brain] Tool result: {result}")
                     tool_results.append({
                         "type": "tool_result",
                         "tool_use_id": block.id,
@@ -350,7 +387,7 @@ def _think_claude(system_prompt: str, user_input: str) -> str:
     except anthropic.RateLimitError:
         return "I've been rate-limited by the API. Give me a moment and try again."
     except Exception as e:
-        print(f"[Aria] Claude API error: {e}")
+        print(f"[Brain] Claude API error: {e}")
         return "Something went wrong reaching the API. Check the console for details."
 
 
@@ -367,40 +404,3 @@ def _extract_text(response) -> str:
         if hasattr(block, "text"):
             return block.text
     return "I processed that, but I'm not sure what to say about it."
-
-
-def _think_local(system_prompt: str, user_input: str) -> str:
-    """Send the prompt to a local Ollama model.
-
-    Note: Ollama doesn't support tool use the same way, so schedule
-    commands are handled by keyword matching as a fallback.
-
-    Args:
-        system_prompt: The full system prompt with personality and memory.
-        user_input: The user's message.
-
-    Returns:
-        The local model's response text.
-    """
-    try:
-        response = httpx.post(
-            f"{OLLAMA_BASE_URL}/api/chat",
-            json={
-                "model": OLLAMA_MODEL,
-                "messages": [
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_input},
-                ],
-                "stream": False,
-            },
-            timeout=60.0,
-        )
-        response.raise_for_status()
-        data = response.json()
-        return data["message"]["content"]
-
-    except httpx.ConnectError:
-        return "I can't reach Ollama — is it running? Start it with 'ollama serve' in another terminal."
-    except Exception as e:
-        print(f"[Aria] Ollama error: {e}")
-        return "Something went wrong with the local model. Check the console."

--- a/core/router.py
+++ b/core/router.py
@@ -1,0 +1,161 @@
+"""
+Aria Intent Router
+==================
+Single source of truth for intent classification in Aria.
+
+Every user query is classified here before any handler is called.
+Classification happens in tier order — cheapest first.
+
+Tier system:
+    TIER 1 (local)  — Python stdlib only. Zero network, zero cost.
+    TIER 2 (web)    — DuckDuckGo scrape + Ollama local reasoning. Zero API cost.
+    TIER 3 (claude) — Claude API. Used only when Tiers 1 and 2 cannot answer.
+
+To add a new intent:
+    1. Add an entry to INTENT_MAP with keywords and tier
+    2. If Tier 1, add a handler function in this file
+    3. If Tier 2, the query is passed to web_search + Ollama automatically
+    4. If Tier 3, the query is passed to Claude automatically
+"""
+
+from __future__ import annotations
+from datetime import datetime
+from core.scheduler import list_reminders
+
+
+# ── Intent map ───────────────────────────────────────────────────────────────
+# Each entry defines: tier and keywords.
+# Keywords are matched case-insensitively against the full query.
+# Tier 1 is checked first, then Tier 2. First match wins.
+
+INTENT_MAP: dict[str, dict] = {
+    # Tier 1 — local, free
+    "time": {
+        "tier": 1,
+        "keywords": [
+            "what time", "current time", "what's the time",
+            "tell me the time", "clock",
+        ],
+    },
+    "date": {
+        "tier": 1,
+        "keywords": [
+            "what date", "what day", "today's date", "what's today",
+            "day is it", "date today",
+        ],
+    },
+    "calendar": {
+        "tier": 1,
+        "keywords": [
+            "what reminders", "show reminders", "list reminders",
+            "my reminders", "my schedule", "what's on", "agenda",
+            "show my schedule",
+        ],
+    },
+
+    # Tier 2 — web + Ollama, free
+    "weather": {
+        "tier": 2,
+        "keywords": [
+            "weather", "temperature", "forecast", "raining", "sunny",
+            "cloudy", "cold outside", "warm outside", "hot outside",
+            "umbrella", "degrees outside", "rain today", "snow",
+        ],
+    },
+    "web_search": {
+        "tier": 2,
+        "keywords": [
+            "search for", "look up", "find out", "who is", "what is",
+            "tell me about", "latest news", "current news", "news about",
+            "who won", "what happened", "how does", "when did",
+            "where is", "price of", "how much is",
+        ],
+    },
+}
+
+
+# ── Classification ────────────────────────────────────────────────────────────
+
+def classify(text: str) -> dict:
+    """Classify user input and return the matched intent and tier.
+
+    Checks intents in tier order (1 before 2) to ensure cheapest
+    handler is always preferred. If no match is found, returns
+    Tier 3 to escalate to Claude.
+
+    Args:
+        text: The transcribed user query. Aria's name may still
+              be present — classification ignores it.
+
+    Returns:
+        dict with keys:
+            intent (str): The matched intent name, or 'claude' if none.
+            tier (int): 1, 2, or 3.
+    """
+    text_lower = text.lower().strip()
+
+    # Check Tier 1 first
+    for intent_name, config in INTENT_MAP.items():
+        if config["tier"] == 1:
+            if _matches(text_lower, config["keywords"]):
+                print(f"[Router] Tier 1 matched: {intent_name} — handling locally.")
+                return {"intent": intent_name, "tier": 1}
+
+    # Then Tier 2
+    for intent_name, config in INTENT_MAP.items():
+        if config["tier"] == 2:
+            if _matches(text_lower, config["keywords"]):
+                print(f"[Router] Tier 2 matched: {intent_name} — web + Ollama.")
+                return {"intent": intent_name, "tier": 2}
+
+    # No match — escalate to Claude
+    print("[Router] No match — Tier 3 escalation to Claude API.")
+    return {"intent": "claude", "tier": 3}
+
+
+def _matches(text: str, keywords: list[str]) -> bool:
+    """Check if any keyword appears in the text.
+
+    Args:
+        text: Lowercased user query.
+        keywords: List of keyword phrases to match against.
+
+    Returns:
+        True if any keyword is found in the text.
+    """
+    return any(kw in text for kw in keywords)
+
+
+# ── Tier 1 local handlers ─────────────────────────────────────────────────────
+
+def handle_time() -> str:
+    """Return the current local time as a spoken string.
+
+    Returns:
+        Human-readable time string for Aria to speak.
+    """
+    now = datetime.now()
+    return f"It's {now.strftime('%H:%M')}, Chan."
+
+
+def handle_date() -> str:
+    """Return the current date as a spoken string.
+
+    Returns:
+        Human-readable date string for Aria to speak.
+    """
+    now = datetime.now()
+    return f"Today is {now.strftime('%A, %d %B %Y')}, Chan."
+
+
+def handle_calendar() -> str:
+    """Return upcoming scheduled reminders from the scheduler.
+
+    Returns:
+        Spoken summary of upcoming items, or a message if none exist.
+    """
+    try:
+        return list_reminders()
+    except Exception as e:
+        print(f"[Router] Calendar lookup error: {e}")
+        return "I couldn't check your schedule right now, Chan."

--- a/core/web_search.py
+++ b/core/web_search.py
@@ -1,67 +1,181 @@
 """
 Aria Web Search Module
 ======================
-Web scraping module for Aria. Provides live data access via
-Playwright headless browser. Built with a scalable dispatch
-architecture — add new handlers by registering them in HANDLERS.
+General-purpose web search for Aria using DuckDuckGo.
 
-Current handlers:
-    - weather: Scrapes wttr.in for Birmingham weather
+Scrapes the DuckDuckGo HTML endpoint for any natural language query
+and extracts the top result snippets as clean plain text.
 
-Future handlers (not yet implemented):
-    - news
-    - job_listings
-    - general_search
+Results are cached in data/web_cache.json with a 15-minute TTL.
+
+The old weather-only handler is retained but deprecated — weather
+queries now go through the general search_web() path.
 """
 
+import hashlib
 import json
 import os
+import re
 from datetime import datetime, timedelta
+from urllib.parse import quote_plus
+
 from config import DATA_DIR
 
 CACHE_FILE = os.path.join(DATA_DIR, "web_cache.json")
-CACHE_TTL_MINUTES = 30
+CACHE_TTL_MINUTES = 15
+MAX_SNIPPETS = 3
 
 
-# ── Handler registry ────────────────────────────────────────────────
-# To add a new handler:
-#   1. Write a _handle_<name>(**kwargs) function below
-#   2. Add an entry here: "name": _handle_<name>
-# The dispatch function search_web() does the rest.
+# ── Public entry point ────────────────────────────────────────────────
 
-HANDLERS: dict = {}
+def search_web(query: str) -> str:
+    """Search the web for a query using DuckDuckGo and return plain text results.
 
-
-def _register(name: str):
-    """Decorator to register a handler function in HANDLERS.
+    Scrapes the DuckDuckGo HTML endpoint and extracts the top 3 result
+    snippets as clean plain text. Results are cached for 15 minutes.
 
     Args:
-        name: The query type this handler responds to.
-    """
-    def decorator(fn):
-        HANDLERS[name] = fn
-        return fn
-    return decorator
-
-
-def search_web(query_type: str, **kwargs) -> str:
-    """Route a query to the appropriate web handler.
-
-    Args:
-        query_type: The type of query (e.g. 'weather', 'news').
-        **kwargs: Additional arguments passed to the handler.
+        query: Natural language search query from the user.
 
     Returns:
-        A plain-text string result, or an error message if scraping fails.
+        Plain text string containing the top search result snippets,
+        or an error message string if scraping fails.
     """
-    handler = HANDLERS.get(query_type)
-    if not handler:
-        return f"No web handler registered for: {query_type}"
+    cache_key = _cache_key(query)
+    cache = _load_cache()
 
-    return handler(**kwargs)
+    # Return cached result if still valid
+    if cache_key in cache and _is_cache_valid(cache[cache_key]):
+        print(f"[WebSearch] Returning cached result for: {query[:50]}")
+        return cache[cache_key]["result"]
+
+    print(f"[WebSearch] Scraping DuckDuckGo for: {query[:50]}...")
+
+    # Try Playwright first, fall back to httpx
+    try:
+        result = _scrape_ddg_playwright(query)
+    except Exception as e:
+        print(f"[WebSearch] Playwright failed ({e}), falling back to httpx...")
+        try:
+            result = _scrape_ddg_httpx(query)
+        except Exception as e2:
+            print(f"[WebSearch] httpx fallback also failed: {e2}")
+            return f"Sorry Chan, I couldn't find results for that query right now."
+
+    if not result or not result.strip():
+        return "I searched but didn't find any relevant results, Chan."
+
+    # Cache the result
+    cache[cache_key] = {
+        "result": result,
+        "timestamp": datetime.now().isoformat(),
+    }
+    _save_cache(cache)
+
+    return result
 
 
-# ── Cache helpers ───────────────────────────────────────────────────
+# ── DuckDuckGo scrapers ──────────────────────────────────────────────
+
+def _scrape_ddg_playwright(query: str) -> str:
+    """Scrape DuckDuckGo HTML endpoint using Playwright headless browser.
+
+    Args:
+        query: The search query string.
+
+    Returns:
+        Plain text snippets from the top results.
+
+    Raises:
+        Exception: If Playwright fails or no results are found.
+    """
+    from playwright.sync_api import sync_playwright
+    from bs4 import BeautifulSoup
+
+    url = f"https://html.duckduckgo.com/html/?q={quote_plus(query)}"
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.goto(url, timeout=15000)
+        html = page.content()
+        browser.close()
+
+    return _extract_snippets(html)
+
+
+def _scrape_ddg_httpx(query: str) -> str:
+    """Fallback DuckDuckGo scrape using httpx (no browser).
+
+    Args:
+        query: The search query string.
+
+    Returns:
+        Plain text snippets from the top results.
+
+    Raises:
+        Exception: If the HTTP request fails.
+    """
+    import httpx
+
+    url = f"https://html.duckduckgo.com/html/?q={quote_plus(query)}"
+    response = httpx.get(
+        url,
+        timeout=10.0,
+        headers={"User-Agent": "Aria/1.0"},
+        follow_redirects=True,
+    )
+    response.raise_for_status()
+    return _extract_snippets(response.text)
+
+
+def _extract_snippets(html: str) -> str:
+    """Extract the top result snippets from DuckDuckGo HTML response.
+
+    Args:
+        html: Raw HTML string from DuckDuckGo.
+
+    Returns:
+        Clean plain text with the top snippets, one per line.
+    """
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html, "html.parser")
+    snippets = []
+
+    # DuckDuckGo HTML results are in <a class="result__snippet"> elements
+    for result in soup.select(".result__snippet")[:MAX_SNIPPETS]:
+        text = result.get_text(strip=True)
+        if text:
+            # Clean up whitespace
+            text = re.sub(r"\s+", " ", text)
+            snippets.append(text)
+
+    if not snippets:
+        # Try fallback selectors
+        for result in soup.select(".result__body")[:MAX_SNIPPETS]:
+            text = result.get_text(strip=True)
+            if text:
+                text = re.sub(r"\s+", " ", text)
+                snippets.append(text)
+
+    return "\n".join(snippets) if snippets else ""
+
+
+# ── Cache helpers ─────────────────────────────────────────────────────
+
+def _cache_key(query: str) -> str:
+    """Generate a stable cache key from a query string.
+
+    Args:
+        query: The search query.
+
+    Returns:
+        A short hash string suitable as a dict key.
+    """
+    normalised = query.lower().strip()
+    return hashlib.md5(normalised.encode()).hexdigest()[:12]
+
 
 def _load_cache() -> dict:
     """Load the web cache from disk.
@@ -105,14 +219,18 @@ def _is_cache_valid(entry: dict) -> bool:
         return False
 
 
-# ── Weather handler ─────────────────────────────────────────────────
+# ── Deprecated weather handler ────────────────────────────────────────
+# DEPRECATED: The dedicated weather handler below is deprecated.
+# Weather queries are now routed through search_web() + Ollama.
+# This function is retained for reference and will be removed
+# once general web search is confirmed stable.
 
-@_register("weather")
-def _handle_weather(location: str = "Birmingham") -> str:
+def _handle_weather_legacy(location: str = "Birmingham") -> str:
     """Scrape current weather from wttr.in for a given location.
 
-    Uses a 30-minute cache to avoid repeated scraping.
-    Tries Playwright first, falls back to httpx if unavailable.
+    .. deprecated::
+        Use search_web() instead. This handler is retained for
+        reference only and will be removed in a future version.
 
     Args:
         location: The city name to fetch weather for.
@@ -120,89 +238,12 @@ def _handle_weather(location: str = "Birmingham") -> str:
     Returns:
         A plain-text weather summary string.
     """
-    cache_key = f"weather_{location.lower()}"
-    cache = _load_cache()
-
-    # Return cached result if still valid
-    if cache_key in cache and _is_cache_valid(cache[cache_key]):
-        print(f"[Aria] Weather: returning cached result for {location}.")
-        return cache[cache_key]["result"]
-
-    print(f"[Aria] Weather: scraping wttr.in for {location}...")
-
-    # Try Playwright first, fall back to httpx
-    try:
-        result = _scrape_wttr_playwright(location)
-    except Exception as e:
-        print(f"[Aria] Playwright failed ({e}), falling back to httpx...")
-        try:
-            result = _scrape_wttr_httpx(location)
-        except Exception as e2:
-            print(f"[Aria] httpx fallback also failed: {e2}")
-            return f"Sorry Chan, I couldn't fetch the weather for {location} right now."
-
-    # Cache the result
-    cache[cache_key] = {
-        "result": result,
-        "timestamp": datetime.now().isoformat(),
-    }
-    _save_cache(cache)
-
-    return result
-
-
-def _scrape_wttr_playwright(location: str) -> str:
-    """Scrape weather using a Playwright headless browser with JSON API.
-
-    Uses wttr.in's JSON endpoint and extracts a human-readable summary.
-
-    Args:
-        location: City name to query.
-
-    Returns:
-        A plain-text weather summary.
-
-    Raises:
-        Exception: If Playwright is not installed or scraping fails.
-    """
-    import json as _json
-    from playwright.sync_api import sync_playwright
-
-    url = f"https://wttr.in/{location}?format=j1"
-    with sync_playwright() as p:
-        browser = p.chromium.launch(headless=True)
-        page = browser.new_page()
-        page.goto(url, timeout=10000)
-        content = page.inner_text("body").strip()
-        browser.close()
-
-    if not content:
-        raise ValueError(f"Empty response from wttr.in for {location}")
-
-    data = _json.loads(content)
-    current = data["current_condition"][0]
-    temp_c = current["temp_C"]
-    desc = current["weatherDesc"][0]["value"]
-    humidity = current["humidity"]
-    wind_mph = current["windspeedMiles"]
-    return f"{location}: {desc}, {temp_c}°C, humidity {humidity}%, wind {wind_mph}mph"
-
-
-def _scrape_wttr_httpx(location: str) -> str:
-    """Fallback weather scrape using httpx (no browser needed for wttr.in format=3).
-
-    Args:
-        location: City name to query.
-
-    Returns:
-        A plain-text weather summary.
-
-    Raises:
-        Exception: If the HTTP request fails.
-    """
     import httpx
 
-    url = f"https://wttr.in/{location}?format=3"
-    response = httpx.get(url, timeout=8.0, headers={"User-Agent": "Aria/1.0"})
-    response.raise_for_status()
-    return response.text.strip()
+    try:
+        url = f"https://wttr.in/{location}?format=3"
+        response = httpx.get(url, timeout=8.0, headers={"User-Agent": "Aria/1.0"})
+        response.raise_for_status()
+        return response.text.strip()
+    except Exception as e:
+        return f"Sorry Chan, I couldn't fetch the weather for {location} right now."

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,4 @@ SQLAlchemy>=2.0.0
 
 # Web scraping (Phase 4 — live data access)
 playwright>=1.40.0
+beautifulsoup4>=4.12.0


### PR DESCRIPTION
#18

Consolidate intent classification into core/router.py with tier-based routing. Tier 1 (local) handles time/date/calendar, Tier 2 (web+Ollama) handles weather/search via DuckDuckGo scraping, Tier 3 (Claude API) handles complex queries. brain.py is now a clean dispatcher.