### PR TITLE
feat: Gemini Flash vision analysis (Stage 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ persistent memory, and live web access. Built in Python on Windows 11.
 ## Features
 - Wake word activation — "Hey Aria"
 - Three-tier intent routing — local, web+Ollama, Claude API
+- Screen understanding — ask "what do you see?" and Aria describes your desktop via Gemini Flash vision
 - Piper TTS — hfc_female medium voice (local ONNX inference)
 - Chibi sprite avatar — desktop overlay with Win32 transparency
 - Persistent memory — SQLite episodic + semantic
@@ -27,7 +28,7 @@ persistent memory, and live web access. Built in Python on Windows 11.
 | 8 | TTS fixes — markdown strip, no truncation | Complete |
 | 9 | Screen capture — Stage 1 desktop capture | Complete |
 | 10 | Conversation mode toggle | Complete |
-| 11 | Screen analysis — Stage 2 Gemini vision | Next session |
+| 11 | Screen analysis — Stage 2 Gemini vision | Complete |
 | 12 | VTube Studio hotkey configuration | Planned |
 | 13 | Gemini integration — reasoning tier | Planned |
 | 14 | Voice recognition training | Planned |
@@ -86,7 +87,8 @@ aria/
 │   ├── scheduler.py       # APScheduler reminders
 │   ├── personality.py     # Aria's evolving personality
 │   ├── web_search.py      # DuckDuckGo scraping + result caching
-│   └── screen_capture.py  # Desktop screenshot capture (Stage 1)
+│   ├── screen_capture.py  # Desktop screenshot capture (Stage 1)
+│   └── vision_analyzer.py # Gemini Flash screen understanding (Stage 2)
 ├── voice/
 │   ├── listener.py        # Microphone capture + silence detection
 │   ├── transcriber.py     # Whisper speech-to-text (CUDA)
@@ -118,6 +120,7 @@ aria/
 | Wake Word | Whisper keyword spotting (no API keys) |
 | Avatar | VTube Studio via pyvts WebSocket |
 | Screen Capture | mss (native Windows GDI) |
+| Vision Analysis | Google Gemini 2.5 Flash |
 | Memory | SQLite (episodic + semantic) + JSON |
 | Scheduler | APScheduler + SQLAlchemy |
 | Web Scraping | Playwright + httpx + BeautifulSoup |

--- a/core/brain.py
+++ b/core/brain.py
@@ -38,6 +38,21 @@ from core.personality import get_system_prompt, record_interaction
 from core.memory import store_episodic, build_memory_context
 from core.scheduler import add_reminder, add_reminder_minutes, list_reminders, cancel_reminder
 from core.web_search import search_web
+from core.vision_analyzer import VisionAnalyzer
+
+
+# ── Lazy singleton for Gemini vision ──────────────────────────────────────────
+# Constructed on first vision query so brain.py imports cheaply even when
+# google-generativeai is missing or GEMINI_API_KEY is unset.
+_vision_analyzer: VisionAnalyzer | None = None
+
+
+def _get_vision_analyzer() -> VisionAnalyzer:
+    """Return the shared VisionAnalyzer, constructing it on first use."""
+    global _vision_analyzer
+    if _vision_analyzer is None:
+        _vision_analyzer = VisionAnalyzer()
+    return _vision_analyzer
 
 
 # ── Ollama configuration ──────────────────────────────────────────────────────
@@ -266,9 +281,12 @@ def think(user_input: str) -> str:
         record_interaction()
         return response
 
-    # ── Tier 2: Web scrape + Ollama ──────────────────────────────────────
+    # ── Tier 2: Web scrape + Ollama, or Gemini vision ────────────────────
     if tier == 2:
-        response = _handle_web_query(user_input)
+        if intent == "vision":
+            response = _handle_vision(user_input)
+        else:
+            response = _handle_web_query(user_input)
         store_episodic("aria", response)
         record_interaction()
         return response
@@ -317,6 +335,31 @@ def _handle_web_query(text: str) -> str:
     except Exception as e:
         print(f"[Brain] Tier 2 failed ({e}) — falling back to Claude.")
         return _handle_claude(text)
+
+
+def _handle_vision(text: str) -> str:
+    """Handle a Tier 2 vision query via Gemini Flash.
+
+    Delegates to VisionAnalyzer, which reads the most recent
+    screenshot written by core.screen_capture and returns a short
+    natural-language reply in Aria's voice (mood-tag prefixed).
+
+    The analyzer never raises — on any failure it returns a
+    graceful fallback string. We still parse the mood tag so the
+    VTS avatar reacts appropriately.
+
+    Args:
+        text: The user's original question (e.g. "what do you see?").
+
+    Returns:
+        Aria's response string, ready for TTS.
+    """
+    print("[Brain] Tier 2 vision — querying Gemini Flash.")
+    analyzer = _get_vision_analyzer()
+    raw = analyzer.analyse_screen(context=text)
+    mood, clean_response = _parse_mood_tag(raw)
+    _trigger_avatar_mood(mood)
+    return clean_response
 
 
 def _query_ollama(prompt: str) -> str:

--- a/core/router.py
+++ b/core/router.py
@@ -48,8 +48,9 @@ INTENT_MAP: dict[str, dict] = {
         "tier": 1,
         "keywords": [
             "what reminders", "show reminders", "list reminders",
-            "my reminders", "my schedule", "what's on", "agenda",
-            "show my schedule",
+            "my reminders", "my schedule", "show my schedule",
+            "what's on my schedule", "what's on my agenda",
+            "what's on today", "agenda",
         ],
     },
 
@@ -62,6 +63,23 @@ INTENT_MAP: dict[str, dict] = {
             "umbrella", "degrees outside", "rain today", "snow",
         ],
     },
+    # Tier 2 — Gemini vision (Stage 2 screen understanding)
+    # Listed before web_search because vision's "what is on my screen"
+    # phrase is more specific than web_search's "what is" prefix and
+    # should win the tie-break. Weather stays ahead of vision since
+    # its keywords ("weather", "temperature") never collide.
+    "vision": {
+        "tier": 2,
+        "keywords": [
+            "what do you see", "what can you see", "what do you notice",
+            "what's on screen", "what's on my screen", "what is on my screen",
+            "look at my screen", "look at the screen", "describe my screen",
+            "analyse my screen", "analyze my screen",
+            "what am i doing", "what game is this", "what game am i playing",
+            "what app is this", "read my screen",
+        ],
+    },
+
     "web_search": {
         "tier": 2,
         "keywords": [
@@ -105,7 +123,8 @@ def classify(text: str) -> dict:
     for intent_name, config in INTENT_MAP.items():
         if config["tier"] == 2:
             if _matches(text_lower, config["keywords"]):
-                print(f"[Router] Tier 2 matched: {intent_name} — web + Ollama.")
+                backend = "Gemini Flash" if intent_name == "vision" else "web + Ollama"
+                print(f"[Router] Tier 2 matched: {intent_name} — {backend}.")
                 return {"intent": intent_name, "tier": 2}
 
     # No match — escalate to Claude

--- a/core/screen_capture.py
+++ b/core/screen_capture.py
@@ -20,6 +20,7 @@ Usage:
 
 from __future__ import annotations
 
+import io
 import os
 import threading
 import time
@@ -27,12 +28,20 @@ from pathlib import Path
 
 import mss
 import mss.tools
+from PIL import Image
 
 # ── Configuration ─────────────────────────────────────────────────────────────
-CAPTURE_DIR     = Path("data/captures")
-LATEST_PATH     = CAPTURE_DIR / "latest.png"
-BUFFER_SIZE     = 10        # Maximum number of screenshots to keep on disk
-CAPTURE_INTERVAL = 5.0      # Seconds between captures
+CAPTURE_DIR      = Path("data/captures")
+LATEST_PATH      = CAPTURE_DIR / "latest.png"
+BUFFER_SIZE      = 10         # Maximum number of screenshots to keep on disk
+CAPTURE_INTERVAL = 5.0        # Seconds between captures
+
+# Compression — downscale full desktop to a size Gemini Flash can swallow cheaply.
+# 1280x720 preserves enough detail for gameplay/UI recognition while keeping
+# payloads small (~150–300 KB per frame vs ~8–9 MB raw).
+COMPRESS_MAX_WIDTH  = 1280
+COMPRESS_MAX_HEIGHT = 720
+PNG_COMPRESS_LEVEL  = 6       # 0 (none) – 9 (max). 6 is PIL's sweet spot.
 
 
 class ScreenCapture:
@@ -115,10 +124,12 @@ class ScreenCapture:
                     time.sleep(self.interval)
 
     def _take_screenshot(self, sct: mss.mss, monitor: dict) -> None:
-        """Capture a single screenshot and save it to disk.
+        """Capture a single screenshot, compress it, and save to disk.
 
-        Saves a timestamped copy and overwrites latest.png.
-        Prunes the buffer if it exceeds BUFFER_SIZE.
+        Saves a timestamped copy and overwrites latest.png. Screenshots
+        are downscaled with PIL (LANCZOS) to COMPRESS_MAX_WIDTH x
+        COMPRESS_MAX_HEIGHT before saving, keeping per-frame payloads
+        small enough for Gemini Flash vision calls.
 
         Args:
             sct: Active mss instance.
@@ -128,17 +139,41 @@ class ScreenCapture:
         timestamp = int(time.time())
         filename  = CAPTURE_DIR / f"frame_{timestamp}.png"
 
-        # Capture and save timestamped frame
+        # Grab the raw frame from the GDI compositor
         screenshot = sct.grab(monitor)
-        mss.tools.to_png(screenshot.rgb, screenshot.size, output=str(filename))
 
-        # Always keep latest.png up to date for Stage 2 analysis
-        mss.tools.to_png(screenshot.rgb, screenshot.size, output=str(LATEST_PATH))
+        # Compress: mss returns BGRA; PIL wants RGB
+        compressed = self._compress_screenshot(screenshot)
 
-        print(f"[Capture] Frame {self.frame_count} saved → {filename.name}")
+        # Save timestamped frame + latest.png
+        compressed.save(filename,    format="PNG", optimize=True, compress_level=PNG_COMPRESS_LEVEL)
+        compressed.save(LATEST_PATH, format="PNG", optimize=True, compress_level=PNG_COMPRESS_LEVEL)
+
+        size_kb = filename.stat().st_size / 1024
+        print(f"[Capture] Frame {self.frame_count} saved → {filename.name} ({size_kb:.0f} KB)")
 
         # Prune rolling buffer
         self._prune_buffer()
+
+    def _compress_screenshot(self, screenshot) -> Image.Image:
+        """Convert an mss screenshot to a downscaled RGB PIL image.
+
+        Uses LANCZOS resampling for high-quality downscaling and
+        preserves aspect ratio — the frame is fit inside a
+        COMPRESS_MAX_WIDTH x COMPRESS_MAX_HEIGHT bounding box.
+
+        Args:
+            screenshot: The raw frame returned by mss.grab().
+
+        Returns:
+            A PIL Image in RGB mode, ready to save as PNG.
+        """
+        # mss gives us BGRA bytes; PIL reads them via 'raw' decoder
+        img = Image.frombytes("RGB", screenshot.size, screenshot.bgra, "raw", "BGRX")
+
+        # Downscale in place, preserving aspect ratio
+        img.thumbnail((COMPRESS_MAX_WIDTH, COMPRESS_MAX_HEIGHT), Image.LANCZOS)
+        return img
 
     def _prune_buffer(self) -> None:
         """Delete oldest screenshots if buffer exceeds BUFFER_SIZE.

--- a/core/vision_analyzer.py
+++ b/core/vision_analyzer.py
@@ -1,0 +1,245 @@
+"""
+core/vision_analyzer.py
+-----------------------
+Stage 2 of Aria's screen awareness pipeline.
+
+Takes the most recent compressed screenshot produced by
+`core.screen_capture.ScreenCapture` and sends it to Google Gemini
+Flash vision for analysis. Returns natural-language commentary in
+Aria's voice — what's on screen, what Chan is doing, what's
+interesting or worth reacting to.
+
+Stage 1 (core/screen_capture.py) writes `data/captures/latest.png`
+every few seconds. Stage 2 reads that file on demand and asks
+Gemini to describe it. Stage 1 runs whether or not Stage 2 is
+configured; Stage 2 degrades gracefully if:
+
+  • GEMINI_API_KEY is missing from config.py
+  • data/captures/latest.png does not yet exist
+  • the google-generativeai package is not installed
+  • the Gemini API call fails
+
+Usage:
+    from core.vision_analyzer import VisionAnalyzer
+    vision = VisionAnalyzer()
+    reply  = vision.analyse_screen("what do you see?")
+    speak(reply)
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+LATEST_SCREENSHOT = Path("data/captures/latest.png")
+
+# ── Model config ──────────────────────────────────────────────────────────────
+# gemini-2.5-flash is the current stable Flash model on the v1beta endpoint.
+# Older "gemini-1.5-flash" was retired — switch here if Google renames again,
+# or swap in "gemini-flash-latest" to always ride the newest release.
+GEMINI_MODEL     = "gemini-2.5-flash"
+MAX_OUTPUT_TOKENS = 400
+REQUEST_TIMEOUT   = 20        # seconds
+STALE_THRESHOLD   = 30        # warn if latest.png is older than this (s)
+
+# ── Aria's vision persona ─────────────────────────────────────────────────────
+# Kept conversational and short — this goes straight to TTS, so prose beats
+# bullet points. The mood tag system (e.g. [HAPPY], [SURPRISED]) is preserved
+# so the avatar can react to what Aria sees.
+VISION_SYSTEM_PROMPT = """You are Aria, Chan's personal AI desktop assistant.
+You can see Chan's screen. Speak in first person, casually, like a friend
+watching over their shoulder — NOT like a vision-model caption.
+
+Style rules:
+- 1–3 short sentences. This is going straight to text-to-speech.
+- Natural spoken English. No bullet points, no markdown, no headings.
+- Be specific about what you see: game names, app names, what Chan is
+  doing, anything unusual. If it's Valorant, call out the agent, map, or
+  scoreboard. If it's code, mention the language or what file it looks like.
+- If Chan asked a question ("what do you see?", "what's happening?"),
+  answer it directly from the screenshot.
+- Start your reply with one mood tag in square brackets:
+  [HAPPY] [NEUTRAL] [THINKING] [SURPRISED] [SAD]
+  Pick whichever matches your reaction to what's on screen.
+- Never say "the image shows" or "in the screenshot" — you're looking
+  at Chan's actual desktop in real time.
+"""
+
+
+class VisionAnalyzer:
+    """Wraps Gemini Flash vision calls against Aria's latest screenshot.
+
+    The analyzer is lazy: it imports google-generativeai and reads the
+    API key on first use so that import-time failures don't break the
+    rest of Aria. Every public method returns a user-facing string —
+    never raises — so `core.brain` can just speak whatever comes back.
+
+    Attributes:
+        available: True if the module can actually call Gemini.
+        _model:    Cached GenerativeModel instance once configured.
+    """
+
+    def __init__(self) -> None:
+        """Configure Gemini if possible; fall back silently otherwise."""
+        self.available: bool = False
+        self._model = None
+        self._configure()
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    def analyse_screen(self, context: str = "") -> str:
+        """Describe the latest screenshot in Aria's voice.
+
+        Args:
+            context: The user's spoken request, e.g. "what do you see?".
+                     Passed to Gemini as additional context so the reply
+                     answers the actual question.
+
+        Returns:
+            A short natural-language reply suitable for TTS. Always a
+            string — on any failure, returns a graceful fallback line.
+        """
+        if not self.available:
+            return (
+                "[NEUTRAL] I can't see your screen right now — "
+                "my vision system isn't configured yet."
+            )
+
+        screenshot = self._load_screenshot()
+        if screenshot is None:
+            return (
+                "[NEUTRAL] I don't have a screenshot to look at yet. "
+                "Give the screen capture a few seconds to warm up."
+            )
+
+        age = self._get_screenshot_age_seconds()
+        if age is not None and age > STALE_THRESHOLD:
+            print(f"[Vision] WARNING: latest.png is {age:.0f}s old — may be stale.")
+
+        prompt = self._build_prompt(context)
+
+        try:
+            reply = self._query_gemini(prompt, screenshot)
+        except Exception as e:
+            print(f"[Vision] ERROR querying Gemini: {e}")
+            return (
+                "[SAD] Something went wrong when I tried to look at your "
+                "screen. I'll try again in a moment."
+            )
+
+        if not reply:
+            return (
+                "[THINKING] I can see your screen but I'm not sure what "
+                "to say about it."
+            )
+
+        return reply.strip()
+
+    # ── Internal ──────────────────────────────────────────────────────────────
+
+    def _configure(self) -> None:
+        """Import google-generativeai and register the API key.
+
+        Silently disables the analyzer if the package or key are missing.
+        """
+        try:
+            import config
+        except Exception as e:
+            print(f"[Vision] Could not import config: {e}")
+            return
+
+        api_key = getattr(config, "GEMINI_API_KEY", None)
+        if not api_key or api_key.startswith("your-"):
+            print("[Vision] GEMINI_API_KEY not set — vision disabled.")
+            return
+
+        try:
+            import google.generativeai as genai
+        except ImportError:
+            print("[Vision] google-generativeai not installed — vision disabled.")
+            return
+
+        try:
+            genai.configure(api_key=api_key)
+            self._model = genai.GenerativeModel(
+                model_name=GEMINI_MODEL,
+                system_instruction=VISION_SYSTEM_PROMPT,
+            )
+            self.available = True
+            print(f"[Vision] Gemini {GEMINI_MODEL} ready.")
+        except Exception as e:
+            print(f"[Vision] Failed to initialise Gemini: {e}")
+
+    def _load_screenshot(self):
+        """Load `data/captures/latest.png` as a PIL Image.
+
+        Returns:
+            A PIL.Image.Image, or None if the file is missing / unreadable.
+        """
+        if not LATEST_SCREENSHOT.exists():
+            print(f"[Vision] No screenshot at {LATEST_SCREENSHOT}")
+            return None
+
+        try:
+            from PIL import Image
+            return Image.open(LATEST_SCREENSHOT)
+        except Exception as e:
+            print(f"[Vision] Failed to open screenshot: {e}")
+            return None
+
+    def _build_prompt(self, context: str) -> str:
+        """Build the user-side prompt that accompanies the screenshot.
+
+        Args:
+            context: The user's spoken request. May be empty.
+
+        Returns:
+            A short instruction for Gemini, anchored to Chan's question.
+        """
+        context = (context or "").strip()
+        if context:
+            return (
+                f"Chan just asked: \"{context}\"\n"
+                f"Look at the attached screenshot of his desktop and "
+                f"answer him directly in your voice."
+            )
+        return (
+            "Describe what's on Chan's desktop right now in 1–3 casual "
+            "sentences. Be specific about apps, games, or what he's doing."
+        )
+
+    def _query_gemini(self, prompt: str, screenshot) -> str:
+        """Send prompt + screenshot to Gemini and return the text reply.
+
+        Args:
+            prompt:     The text portion of the request.
+            screenshot: A PIL Image of the desktop.
+
+        Returns:
+            The plain-text reply from Gemini. Empty string if none.
+        """
+        import google.generativeai as genai  # noqa: F401
+
+        response = self._model.generate_content(
+            [prompt, screenshot],
+            generation_config={
+                "max_output_tokens": MAX_OUTPUT_TOKENS,
+                "temperature": 0.7,
+            },
+            request_options={"timeout": REQUEST_TIMEOUT},
+        )
+
+        # Gemini returns a candidate list; .text is the convenience accessor.
+        text = getattr(response, "text", "") or ""
+        return text
+
+    def _get_screenshot_age_seconds(self) -> float | None:
+        """Return how old `latest.png` is, in seconds.
+
+        Returns:
+            Seconds since the file was last modified, or None if missing.
+        """
+        if not LATEST_SCREENSHOT.exists():
+            return None
+        return time.time() - LATEST_SCREENSHOT.stat().st_mtime

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,9 @@ SQLAlchemy>=2.0.0
 # Screen capture (Stage 1 — desktop screenshots via GDI)
 mss>=9.0.0
 
+# Vision analysis (Stage 2 — Gemini Flash screen understanding)
+google-generativeai>=0.7.0
+
 # Web scraping (Phase 4 — live data access)
 playwright>=1.40.0
 beautifulsoup4>=4.12.0


### PR DESCRIPTION
## Summary
- Wires Google Gemini 2.5 Flash to analyse Aria's desktop screenshots and return short, TTS-friendly commentary in her voice.
- New Tier 2 `vision` intent — "what do you see?", "what's on my screen?", "what game is this?", etc. — dispatches to Gemini instead of the web scraper.
- Stage 1 screenshots are now compressed by Pillow (LANCZOS → 1280×720 bounding box), dropping per-frame size from ~8.9 MB raw mss output to ~150 KB — cheap to send on every vision call.

Closes #27. Builds on Stage 1 (#24) and the conversation mode toggle (#25).

## Changes
- **`core/screen_capture.py`** — new `_compress_screenshot()` helper using `Image.frombytes(..., "BGRX")` to pull mss's BGRA buffer directly into PIL, then LANCZOS `thumbnail()` and `optimize=True` PNG save.
- **`core/vision_analyzer.py`** *(new)* — `VisionAnalyzer` class wrapping Gemini Flash. Lazy config: imports `google-generativeai` and reads `GEMINI_API_KEY` on first use. System prompt tuned for TTS (1–3 sentences, mood-tag prefix, no markdown, first-person). Every public method returns a string — never raises. Graceful fallbacks for missing SDK, missing key, missing `latest.png`, and Gemini API errors.
- **`core/router.py`** — new `vision` intent (Tier 2) with 17 keyword phrases. Tightened `calendar`'s loose `"what's on"` keyword to `"what's on my schedule"` etc. so it no longer swallows `"what's on my screen"`. Vision ordered before `web_search` so its specific phrases win the tie-break over `web_search`'s `"what is"` prefix. Tier 2 log line now prints `Gemini Flash` vs `web + Ollama` accurately.
- **`core/brain.py`** — lazy `VisionAnalyzer` singleton via `_get_vision_analyzer()`. Tier 2 dispatch now branches on `intent == "vision"` → `_handle_vision()` vs the existing `_handle_web_query()`. `_handle_vision()` preserves mood-tag parsing and avatar trigger parity with the other handlers.
- **`requirements.txt`** — `google-generativeai>=0.7.0` under a new "Vision analysis (Stage 2)" section.
- **`README.md`** — Features bullet, Phase 11 marked Complete, new `Vision Analysis | Google Gemini 2.5 Flash` row, and `vision_analyzer.py` in the project structure.

## Model note
The spec originally called for `gemini-1.5-flash`, but that model has been retired from the `v1beta` endpoint and now returns a 404. Switched to `gemini-2.5-flash` (current stable GA Flash model, vision-capable) with a comment in `vision_analyzer.py` documenting the swap. That 404 actually doubled as free validation of the API-error graceful-fallback path — Aria returned `"[SAD] Something went wrong when I tried to look at your screen…"` cleanly instead of crashing.

## Deprecation heads-up *(not addressed in this PR)*
The `google-generativeai` package emits a `FutureWarning` — Google has deprecated it in favour of the newer `google.genai` SDK. Everything still works fine and matches the spec, but this is a good candidate for a follow-up migration ticket.

## Test plan
- [x] Compression size — 4s live capture, frames measured 151–194 KB (target <300 KB)
- [x] Vision routing (mocked Gemini) — `what do you see?` classifies as `vision/2`, dispatches to `_handle_vision`, mood tag extracted, avatar trigger fires
- [x] Router regression battery — 16/16 pass, including collision cases: `"what's on my schedule"` → calendar, `"what's on my screen"` → vision, `"what is the weather"` → weather, `"what is the capital"` → web_search
- [x] **Live Gemini 2.5 Flash call** — asked "what am I doing right now?" and got:
  > *"[THINKING] You're looking at your Google AI Studio API keys on the left, and on the right, you're deep in notes for building the Aria AI desktop assistant for Windows, specifically working on some 'vision' and 'Gemini Flash' integration. Looks like a lot of development work!"*
  
  Response times 2.4s and 3.1s across two prompts.
- [x] Graceful fallback — moved `latest.png` aside, analyzer returned `"[NEUTRAL] I don't have a screenshot to look at yet. Give the screen capture a few seconds to warm up."` — no crash, file restored automatically.
- [ ] Full voice-loop run on Chan's machine: wake Aria, say "what do you see?", hear Gemini's reply out of Piper, confirm avatar mood changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)