### PR TITLE
feat: VTS Hiyori_A hotkey config + google.genai SDK migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ persistent memory, and live web access. Built in Python on Windows 11.
 | 2 | Claude brain + SQLite memory | Complete |
 | 3 | Piper TTS — hfc_female medium | Complete |
 | 4 | Web scraping — DuckDuckGo + Ollama | Complete |
-| 5 | Avatar — VTube Studio (Tororo model) | Complete |
+| 5 | Avatar — VTube Studio (Hiyori_A model) | Complete |
 | 6 | Speech accuracy — VAD, noise reduction | Complete |
 | 7 | Intent router — three-tier system | Complete |
 | 8 | TTS fixes — markdown strip, no truncation | Complete |
 | 9 | Screen capture — Stage 1 desktop capture | Complete |
 | 10 | Conversation mode toggle | Complete |
 | 11 | Screen analysis — Stage 2 Gemini vision | Complete |
-| 12 | VTube Studio hotkey configuration | Planned |
+| 12 | VTube Studio hotkey config — Hiyori expressions | Complete |
 | 13 | Gemini integration — reasoning tier | Planned |
 | 14 | Voice recognition training | Planned |
 
@@ -118,7 +118,7 @@ aria/
 | Voice Input | faster-whisper large-v2 (CUDA + VAD) |
 | Voice Output | Piper TTS (hfc_female medium) |
 | Wake Word | Whisper keyword spotting (no API keys) |
-| Avatar | VTube Studio via pyvts WebSocket |
+| Avatar | VTube Studio — Hiyori_A (Live2D) via pyvts |
 | Screen Capture | mss (native Windows GDI) |
 | Vision Analysis | Google Gemini 2.5 Flash |
 | Memory | SQLite (episodic + semantic) + JSON |

--- a/avatar/vts_controller.py
+++ b/avatar/vts_controller.py
@@ -37,26 +37,26 @@ PLUGIN_DEVELOPER = "chansg"
 VTS_HOST = "localhost"
 VTS_PORT = 8001
 
-# ── State to hotkey mapping ───────────────────────────────────────────────────
+# ── State to hotkey mapping — Hiyori_A model ─────────────────────────────────
 # These map Aria's internal states to VTS hotkey names.
-# Update hotkey names in config.py to match your model's actual hotkeys.
+# Override in config.py if using a different Live2D model.
 DEFAULT_STATE_HOTKEYS = {
-    "idle":      None,   # Default model pose — no hotkey needed
-    "listening": None,   # Same as idle for now
-    "thinking":  None,   # Can be mapped to a blinking/looking expression
-    "dormant":   None,   # Sleeping expression if model has one
+    "idle":      None,           # Base state — Hiyori rests naturally
+    "listening": "hiyori_m05",   # Active listening expression
+    "thinking":  "hiyori_m03",   # Pensive, looking to the side
+    "dormant":   None,           # Sleeping — no hotkey at this stage
 }
 
-# ── Mood tag to hotkey mapping ────────────────────────────────────────────────
+# ── Mood tag to hotkey mapping — Hiyori_A model ──────────────────────────────
 # Maps mood tags returned by brain.py to VTS hotkey names.
 # Hotkey names must match exactly what is configured in VTube Studio.
-# Update these in config.py once you have keybinds set up in VTS.
+# Override in config.py if using a different Live2D model.
 DEFAULT_MOOD_HOTKEYS = {
-    "HAPPY":     None,
-    "NEUTRAL":   None,
-    "THINKING":  None,
-    "SURPRISED": None,
-    "SAD":       None,
+    "HAPPY":     "hiyori_m01",   # Bright cheerful smile
+    "NEUTRAL":   None,           # Base state — no hotkey fired
+    "THINKING":  "hiyori_m03",   # Pensive expression
+    "SURPRISED": "hiyori_m02",   # Wide eyes, open mouth
+    "SAD":       "hiyori_m04",   # Downcast, saddened
 }
 
 
@@ -207,9 +207,10 @@ class VTSController:
         """Trigger a named hotkey in VTube Studio.
 
         Args:
-            hotkey_name: The exact hotkey name as configured in VTS.
+            hotkey_name: Exact hotkey name as configured in VTS.
+                         If None or empty, returns immediately.
         """
-        if not self._vts or not self.connected:
+        if not hotkey_name or not self._vts or not self.connected:
             return
         try:
             response = await self._vts.request(

--- a/config.example.py
+++ b/config.example.py
@@ -20,26 +20,27 @@ MAX_CONVERSATION_TURNS = 10   # Recent exchanges sent as context to Claude
 MAX_SPEAK_LENGTH = 500        # Max characters per TTS utterance
 TRANSCRIPTION_TIMEOUT = 15    # Seconds before aborting a Whisper transcription
 
-# --- VTube Studio — avatar expression hotkeys ---
-# Set these to match the exact hotkey names configured in VTube Studio
-# Leave as None if the hotkey is not yet configured
+# ── VTube Studio — Hiyori_A Model Configuration ───────────────────────────────
+# Hotkey names must match exactly what is configured in VTube Studio.
+# These have been manually created and confirmed in VTS for the Hiyori_A model.
+
 VTS_STATE_HOTKEYS = {
-    "idle":      None,   # Default resting expression
-    "listening": None,   # Alert/attentive expression
-    "thinking":  None,   # Contemplative expression
-    "dormant":   None,   # Sleeping expression
+    "idle":      None,           # Base state — no hotkey, Hiyori rests naturally
+    "listening": "hiyori_m05",   # Active listening expression
+    "thinking":  "hiyori_m03",   # Pensive, looking to the side
+    "dormant":   None,           # Sleeping — no hotkey at this stage
 }
 
 VTS_MOOD_HOTKEYS = {
-    "HAPPY":     None,   # Happy/cheerful expression
-    "NEUTRAL":   None,   # Default neutral expression
-    "THINKING":  None,   # Thoughtful expression
-    "SURPRISED": None,   # Surprised expression
-    "SAD":       None,   # Sad/concerned expression
+    "HAPPY":     "hiyori_m01",   # Bright cheerful smile
+    "NEUTRAL":   None,           # Base state — no hotkey fired
+    "THINKING":  "hiyori_m03",   # Pensive expression
+    "SURPRISED": "hiyori_m02",   # Wide eyes, open mouth
+    "SAD":       "hiyori_m04",   # Downcast, saddened
 }
 
 # VTube Studio API
-VTS_PORT = 8001
+VTS_PORT    = 8001
 VTS_ENABLED = True   # Set to False to run without VTube Studio
 
 # ── Screen Capture ────────────────────────────────────────────────────────────

--- a/core/vision_analyzer.py
+++ b/core/vision_analyzer.py
@@ -70,20 +70,20 @@ Style rules:
 class VisionAnalyzer:
     """Wraps Gemini Flash vision calls against Aria's latest screenshot.
 
-    The analyzer is lazy: it imports google-generativeai and reads the
+    The analyzer is lazy: it imports google.genai and reads the
     API key on first use so that import-time failures don't break the
     rest of Aria. Every public method returns a user-facing string —
     never raises — so `core.brain` can just speak whatever comes back.
 
     Attributes:
         available: True if the module can actually call Gemini.
-        _model:    Cached GenerativeModel instance once configured.
+        _client:   Cached genai.Client instance once configured.
     """
 
     def __init__(self) -> None:
         """Configure Gemini if possible; fall back silently otherwise."""
         self.available: bool = False
-        self._model = None
+        self._client = None
         self._configure()
 
     # ── Public API ────────────────────────────────────────────────────────────
@@ -139,7 +139,7 @@ class VisionAnalyzer:
     # ── Internal ──────────────────────────────────────────────────────────────
 
     def _configure(self) -> None:
-        """Import google-generativeai and register the API key.
+        """Import google.genai and create a Gemini client.
 
         Silently disables the analyzer if the package or key are missing.
         """
@@ -155,19 +155,15 @@ class VisionAnalyzer:
             return
 
         try:
-            import google.generativeai as genai
+            from google import genai
         except ImportError:
-            print("[Vision] google-generativeai not installed — vision disabled.")
+            print("[Vision] google-genai not installed — vision disabled.")
             return
 
         try:
-            genai.configure(api_key=api_key)
-            self._model = genai.GenerativeModel(
-                model_name=GEMINI_MODEL,
-                system_instruction=VISION_SYSTEM_PROMPT,
-            )
+            self._client = genai.Client(api_key=api_key)
             self.available = True
-            print(f"[Vision] Gemini {GEMINI_MODEL} ready.")
+            print(f"[Vision] Gemini {GEMINI_MODEL} ready (google.genai SDK).")
         except Exception as e:
             print(f"[Vision] Failed to initialise Gemini: {e}")
 
@@ -219,18 +215,18 @@ class VisionAnalyzer:
         Returns:
             The plain-text reply from Gemini. Empty string if none.
         """
-        import google.generativeai as genai  # noqa: F401
-
-        response = self._model.generate_content(
-            [prompt, screenshot],
-            generation_config={
+        response = self._client.models.generate_content(
+            model=GEMINI_MODEL,
+            contents=[prompt, screenshot],
+            config={
+                "system_instruction": VISION_SYSTEM_PROMPT,
                 "max_output_tokens": MAX_OUTPUT_TOKENS,
                 "temperature": 0.7,
+                "http_options": {"timeout": REQUEST_TIMEOUT * 1000},
             },
-            request_options={"timeout": REQUEST_TIMEOUT},
         )
 
-        # Gemini returns a candidate list; .text is the convenience accessor.
+        # .text is the convenience accessor for the first candidate.
         text = getattr(response, "text", "") or ""
         return text
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ SQLAlchemy>=2.0.0
 mss>=9.0.0
 
 # Vision analysis (Stage 2 — Gemini Flash screen understanding)
-google-generativeai>=0.7.0
+google-genai>=1.0.0
 
 # Web scraping (Phase 4 — live data access)
 playwright>=1.40.0


### PR DESCRIPTION
## Summary
- Configures VTube Studio hotkey mappings for the **Hiyori_A** Live2D model, wiring Aria's mood tags to actual expressions in VTS.
- Replaces all Tororo references with Hiyori_A across the codebase.
- Migrates from the deprecated `google-generativeai` SDK to `google.genai` (eliminates FutureWarning on every import).

Closes #31.

## VTS Hotkey Mappings
| Mood/State | Hotkey | Expression |
|---|---|---|
| HAPPY | `hiyori_m01` | Bright cheerful smile |
| SURPRISED | `hiyori_m02` | Wide eyes, open mouth |
| THINKING | `hiyori_m03` | Pensive, looking to side |
| SAD | `hiyori_m04` | Downcast, saddened |
| NEUTRAL | `None` | Base state — no hotkey fired |
| listening (state) | `hiyori_m05` | Active listening expression |
| idle (state) | `None` | Base state |
| dormant (state) | `None` | No hotkey at this stage |

## Changes
### Commit 1: VTS Hiyori_A hotkey configuration
- **`config.example.py`** — populated `VTS_STATE_HOTKEYS` and `VTS_MOOD_HOTKEYS` with confirmed Hiyori_A hotkey names. Updated section header.
- **`avatar/vts_controller.py`** — updated `DEFAULT_STATE_HOTKEYS` and `DEFAULT_MOOD_HOTKEYS` to Hiyori_A mappings. Added explicit `None` guard in `_trigger_hotkey()` — returns immediately if `hotkey_name` is None or empty.
- **`README.md`** — replaced Tororo with Hiyori_A in Phase 5. Marked Phase 12 (VTS hotkey config) as Complete. Updated Tech Stack avatar row.

### Commit 2: google.genai SDK migration
- **`core/vision_analyzer.py`** — replaced `import google.generativeai as genai` / `genai.configure()` / `GenerativeModel` with `from google import genai` / `genai.Client()` / `client.models.generate_content()`. System instruction now passed per-request in the config dict.
- **`requirements.txt`** — `google-generativeai>=0.7.0` → `google-genai>=1.0.0`.

## ⚠️ Action required after merge
Update your local `config.py` with the Hiyori_A hotkey mappings:
```python
VTS_STATE_HOTKEYS = {
    "idle":      None,
    "listening": "hiyori_m05",
    "thinking":  "hiyori_m03",
    "dormant":   None,
}

VTS_MOOD_HOTKEYS = {
    "HAPPY":     "hiyori_m01",
    "NEUTRAL":   None,
    "THINKING":  "hiyori_m03",
    "SURPRISED": "hiyori_m02",
    "SAD":       "hiyori_m04",
}
```

## Test plan
- [x] VTSController smoke test — all state/mood paths handled without crash (None guard, disconnected state)
- [x] `google.genai` SDK: `VisionAnalyzer.available = True`, `_client type: Client`, no FutureWarning
- [x] Graceful fallback for missing screenshot verified
- [x] Graceful fallback for API error (503) verified
- [x] No Tororo references remain in codebase (`grep -ri tororo` returns empty)
- [x] Live VTS test on Chan's rig: say mood-triggering phrases, confirm Hiyori expressions change in VTube Studio

🤖 Generated with [Claude Code](https://claude.com/claude-code)