### PR TITLE
feat: Gemini Flash as unified Tier 2 reasoning engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ persistent memory, and live web access. Built in Python on Windows 11.
 
 ## Features
 - Wake word activation — "Hey Aria"
-- Three-tier intent routing — local, web+Ollama, Claude API
+- Three-tier intent routing — local, Gemini Flash (web+screen), Claude API
 - Screen understanding — ask "what do you see?" and Aria describes your desktop via Gemini Flash vision
+- Unified Tier 2 reasoning — web scrape + screenshot in a single Gemini call
 - Piper TTS — hfc_female medium voice (local ONNX inference)
 - Chibi sprite avatar — desktop overlay with Win32 transparency
 - Persistent memory — SQLite episodic + semantic
-- DuckDuckGo web scraping + Ollama local reasoning (Tier 2)
+- DuckDuckGo web scraping + Gemini Flash reasoning (Tier 2, Ollama offline fallback)
 - Scheduling and reminders via APScheduler
 - Voice recognition training with WER scoring
 
@@ -30,8 +31,10 @@ persistent memory, and live web access. Built in Python on Windows 11.
 | 10 | Conversation mode toggle | Complete |
 | 11 | Screen analysis — Stage 2 Gemini vision | Complete |
 | 12 | VTube Studio hotkey config — Hiyori expressions | Complete |
-| 13 | Gemini integration — reasoning tier | Planned |
-| 14 | Voice recognition training | Planned |
+| 13 | Gemini unified Tier 2 — web + screen reasoning | Complete |
+| 14 | TTS sentence splitting — no more cut-off | Complete |
+| 15 | Vision keyword expansion — natural language | Complete |
+| 16 | Voice recognition training | Planned |
 
 ## Setup
 
@@ -113,7 +116,7 @@ aria/
 | Component | Technology |
 |-----------|-----------|
 | AI Brain (Tier 3) | Anthropic Claude API (Haiku + Sonnet) |
-| Local Reasoning (Tier 2) | Ollama + DuckDuckGo web scraping |
+| Reasoning (Tier 2) | Gemini 2.5 Flash (web + screen) — Ollama Mistral offline fallback |
 | Intent Router | Keyword-based tier classification |
 | Voice Input | faster-whisper large-v2 (CUDA + VAD) |
 | Voice Output | Piper TTS (hfc_female medium) |

--- a/config.example.py
+++ b/config.example.py
@@ -9,7 +9,13 @@ ANTHROPIC_API_KEY = "your-anthropic-api-key-here"
 PICOVOICE_API_KEY = "your-picovoice-api-key-here"
 OPENWEATHER_API_KEY = ""  # Optional — currently using web scraping
 
-# --- Ollama (local LLM for Tier 2 reasoning) ---
+# ── Reasoning engine ───────────────────────────────────────────────────────
+# Tier 2 queries use Gemini Flash by default (web scrape + screenshot).
+# USE_LOCAL_FALLBACK = True forces Tier 2 queries through Ollama/Mistral
+# instead of Gemini. Use when offline or conserving Gemini API quota.
+USE_LOCAL_FALLBACK = False
+
+# --- Ollama (local LLM for Tier 2 fallback) ---
 # Run `ollama list` to see which models are installed locally.
 # The model name here must match exactly — a mismatch returns 404.
 OLLAMA_BASE_URL = "http://localhost:11434"

--- a/core/brain.py
+++ b/core/brain.py
@@ -9,7 +9,8 @@ No intent classification logic lives here.
 
 Tier dispatch:
     Tier 1 — router.py local handlers (time, date, calendar)
-    Tier 2 — web_search.py + Ollama local model reasoning
+    Tier 2 — Gemini Flash (web scrape + screenshot) as primary reasoner,
+             Ollama/Mistral as offline fallback (USE_LOCAL_FALLBACK=True)
     Tier 3 — Claude API for complex open-ended reasoning only
 
 Preserved across all tiers:
@@ -33,6 +34,13 @@ from config import (
     OLLAMA_MODEL,
     MAX_CONVERSATION_TURNS,
 )
+
+# USE_LOCAL_FALLBACK may not exist in older config.py files.
+# Default to False (Gemini primary) if the toggle is missing.
+try:
+    from config import USE_LOCAL_FALLBACK
+except ImportError:
+    USE_LOCAL_FALLBACK = False
 from core.router import classify, handle_time, handle_date, handle_calendar
 from core.personality import get_system_prompt, record_interaction
 from core.memory import store_episodic, build_memory_context
@@ -282,12 +290,12 @@ def think(user_input: str) -> str:
         record_interaction()
         return response
 
-    # ── Tier 2: Web scrape + Ollama, or Gemini vision ────────────────────
+    # ── Tier 2: Gemini Flash (web + screen) or vision ──────────────────
     if tier == 2:
         if intent == "vision":
             response = _handle_vision(user_input)
         else:
-            response = _handle_web_query(user_input)
+            response = _handle_web_query(user_input, intent=intent)
         store_episodic("aria", response)
         record_interaction()
         return response
@@ -301,41 +309,58 @@ def think(user_input: str) -> str:
 
 # ── Tier 2 handler ────────────────────────────────────────────────────────────
 
-def _handle_web_query(text: str) -> str:
-    """Handle a Tier 2 query: scrape web, reason with Ollama.
+def _handle_web_query(text: str, intent: str = "") -> str:
+    """Handle a Tier 2 query using Gemini Flash as primary reasoner.
 
-    Falls back to Claude if Ollama is unavailable.
+    Pipeline:
+        1. If USE_LOCAL_FALLBACK is True, skip Gemini entirely and
+           route to Ollama via _handle_ollama_fallback().
+        2. Scrape web context via DuckDuckGo.
+        3. Send query + web context + screenshot to Gemini Flash
+           via VisionAnalyzer.reason_with_context().
+        4. If Gemini fails, fall back to Ollama.
+        5. If Ollama also fails, escalate to Claude (Tier 3).
 
     Args:
         text: The user's original query.
+        intent: The matched intent name from router.py (for logging).
 
     Returns:
         Aria's response based on web-retrieved content.
     """
+    # ── Local fallback mode (offline / quota conservation) ───────────
+    if USE_LOCAL_FALLBACK:
+        print("[Brain] USE_LOCAL_FALLBACK is True — routing to Ollama.")
+        return _handle_ollama_fallback(text)
+
+    # ── Scrape web context ───────────────────────────────────────────
+    web_context = ""
     try:
         web_context = search_web(text)
+    except Exception as e:
+        print(f"[Brain] Web scrape failed ({e}) — continuing without web context.")
 
-        prompt = (
-            "You are Aria, a helpful and concise personal AI assistant. "
-            "Answer the following question using only the web information provided. "
-            "Be brief — 1 to 3 sentences maximum. Address the user as Chan. "
-            "If the web information does not contain a clear answer, say so.\n\n"
-            "IMPORTANT: Begin every response with a mood tag in square brackets. "
-            "Choose from: [HAPPY] [NEUTRAL] [THINKING] [SURPRISED] [SAD]. "
-            "Example: '[HAPPY] Of course, Chan! Here's what I found.'\n\n"
-            f"Web information:\n{web_context}\n\n"
-            f"Question: {text}\n\n"
-            "Answer:"
+    # ── Primary: Gemini Flash (web + screenshot) ─────────────────────
+    try:
+        analyzer = _get_vision_analyzer()
+        if not analyzer.available:
+            raise RuntimeError("Gemini not available.")
+
+        raw = analyzer.reason_with_context(
+            query=text,
+            web_context=web_context,
+            include_screen=True,
         )
-
-        raw = _query_ollama(prompt)
+        print(f"[Brain] Gemini Tier 2 response — {len(raw)} chars.")
         mood, clean_response = _parse_mood_tag(raw)
         _trigger_avatar_mood(mood)
         return clean_response
 
     except Exception as e:
-        print(f"[Brain] Tier 2 failed ({e}) — falling back to Claude.")
-        return _handle_claude(text)
+        print(f"[Brain] Gemini failed ({e}) — falling back to Ollama.")
+
+    # ── Fallback: Ollama local model ─────────────────────────────────
+    return _handle_ollama_fallback(text, web_context=web_context)
 
 
 def _handle_vision(text: str) -> str:
@@ -349,12 +374,22 @@ def _handle_vision(text: str) -> str:
     graceful fallback string. We still parse the mood tag so the
     VTS avatar reacts appropriately.
 
+    If USE_LOCAL_FALLBACK is True, vision queries return a polite
+    decline since Ollama cannot process screenshots.
+
     Args:
         text: The user's original question (e.g. "what do you see?").
 
     Returns:
         Aria's response string, ready for TTS.
     """
+    if USE_LOCAL_FALLBACK:
+        print("[Brain] USE_LOCAL_FALLBACK is True — vision unavailable offline.")
+        return (
+            "I can't see your screen right now, Chan — "
+            "I'm running in offline mode without Gemini."
+        )
+
     print("[Brain] Tier 2 vision — querying Gemini Flash.")
     analyzer = _get_vision_analyzer()
     raw = analyzer.analyse_screen(context=text)
@@ -395,6 +430,51 @@ def _query_ollama(prompt: str) -> str:
     if not result:
         raise ValueError("Ollama returned an empty response.")
     return result
+
+
+def _handle_ollama_fallback(text: str, web_context: str = "") -> str:
+    """Handle a Tier 2 query using Ollama as the offline fallback.
+
+    Called when Gemini is unavailable or USE_LOCAL_FALLBACK is True.
+    If web_context is empty, scrapes it fresh. If Ollama also fails,
+    escalates to Claude (Tier 3).
+
+    Args:
+        text: The user's original query.
+        web_context: Pre-scraped web context. Empty string triggers a fresh scrape.
+
+    Returns:
+        Aria's response string, ready for TTS.
+    """
+    # Scrape web context if not already provided
+    if not web_context:
+        try:
+            web_context = search_web(text)
+        except Exception as e:
+            print(f"[Brain] Web scrape failed in Ollama fallback ({e}).")
+
+    prompt = (
+        "You are Aria, a helpful and concise personal AI assistant. "
+        "Answer the following question using only the web information provided. "
+        "Be brief — 1 to 3 sentences maximum. Address the user as Chan. "
+        "If the web information does not contain a clear answer, say so.\n\n"
+        "IMPORTANT: Begin every response with a mood tag in square brackets. "
+        "Choose from: [HAPPY] [NEUTRAL] [THINKING] [SURPRISED] [SAD]. "
+        "Example: '[HAPPY] Of course, Chan! Here's what I found.'\n\n"
+        f"Web information:\n{web_context}\n\n"
+        f"Question: {text}\n\n"
+        "Answer:"
+    )
+
+    try:
+        raw = _query_ollama(prompt)
+        print(f"[Brain] Ollama fallback response — {len(raw)} chars.")
+        mood, clean_response = _parse_mood_tag(raw)
+        _trigger_avatar_mood(mood)
+        return clean_response
+    except Exception as e:
+        print(f"[Brain] Ollama fallback failed ({e}) — escalating to Claude.")
+        return _handle_claude(text)
 
 
 # ── Tier 3 handler ────────────────────────────────────────────────────────────

--- a/core/router.py
+++ b/core/router.py
@@ -71,12 +71,19 @@ INTENT_MAP: dict[str, dict] = {
     "vision": {
         "tier": 2,
         "keywords": [
+            # Direct vision requests
             "what do you see", "what can you see", "what do you notice",
             "what's on screen", "what's on my screen", "what is on my screen",
             "look at my screen", "look at the screen", "describe my screen",
             "analyse my screen", "analyze my screen",
             "what am i doing", "what game is this", "what game am i playing",
             "what app is this", "read my screen",
+            # Natural language variants
+            "can you see", "are you able to see", "do you see",
+            "look at this", "what are you looking at",
+            "describe what you see", "see my screen",
+            "looking at my screen", "what do you observe",
+            "tell me what you see",
         ],
     },
 
@@ -123,7 +130,7 @@ def classify(text: str) -> dict:
     for intent_name, config in INTENT_MAP.items():
         if config["tier"] == 2:
             if _matches(text_lower, config["keywords"]):
-                backend = "Gemini Flash" if intent_name == "vision" else "web + Ollama"
+                backend = "Gemini Flash (vision)" if intent_name == "vision" else "Gemini Flash (web + screen)"
                 print(f"[Router] Tier 2 matched: {intent_name} — {backend}.")
                 return {"intent": intent_name, "tier": 2}
 

--- a/core/vision_analyzer.py
+++ b/core/vision_analyzer.py
@@ -136,6 +136,86 @@ class VisionAnalyzer:
 
         return reply.strip()
 
+    def reason_with_context(
+        self,
+        query: str,
+        web_context: str = "",
+        include_screen: bool = True,
+    ) -> str:
+        """Send query, web context, and optionally the screen to Gemini.
+
+        This is the unified Tier 2 reasoning call. Gemini receives:
+          - The user's original query
+          - Raw web scrape results (if available)
+          - The current screenshot (if screen capture is running)
+
+        Gemini synthesises all inputs into a single coherent response,
+        eliminating the need for separate weather, web, or gaming handlers.
+
+        Args:
+            query: The user's original natural language query.
+            web_context: Raw text from DuckDuckGo scrape. Empty string if
+                         no web context is needed or scrape failed.
+            include_screen: Whether to include latest.png in the request.
+                            Set False for pure text queries with no screen
+                            relevance.
+
+        Returns:
+            Gemini's response as plain text for Aria to speak.
+
+        Raises:
+            RuntimeError: If Gemini is unavailable or the call fails.
+        """
+        if not self.available:
+            raise RuntimeError("Gemini not available — API key missing or SDK not installed.")
+
+        content_parts = []
+
+        # Include screenshot if available and recent enough
+        if include_screen:
+            screenshot = self._load_screenshot()
+            if screenshot is not None:
+                age = self._get_screenshot_age_seconds()
+                if age is not None and age < 60:
+                    content_parts.append(screenshot)
+                    print(f"[Vision] Including screenshot ({age:.0f}s old) in Gemini request.")
+                else:
+                    print(f"[Vision] Screenshot too old ({age:.0f}s) — skipping from request.")
+
+        # Build the unified prompt
+        prompt_parts = [
+            "You are Aria, a smart personal AI assistant for Chan. "
+            "Be concise — 1 to 3 sentences maximum. Conversational and direct. "
+            "Do not use markdown formatting. Address the user as Chan.\n\n"
+            "IMPORTANT: Begin your response with a mood tag in square brackets. "
+            "Choose from: [HAPPY] [NEUTRAL] [THINKING] [SURPRISED] [SAD].\n\n"
+        ]
+
+        if web_context:
+            prompt_parts.append(
+                f"Web search results for context:\n{web_context}\n\n"
+            )
+
+        prompt_parts.append(f"User query: {query}\n\nAnswer:")
+        content_parts.append("".join(prompt_parts))
+
+        try:
+            response = self._client.models.generate_content(
+                model=GEMINI_MODEL,
+                contents=content_parts,
+                config={
+                    "max_output_tokens": MAX_OUTPUT_TOKENS,
+                    "temperature": 0.7,
+                    "http_options": {"timeout": REQUEST_TIMEOUT * 1000},
+                },
+            )
+            result = getattr(response, "text", "") or ""
+            result = result.strip()
+            print(f"[Vision] Gemini unified response — {len(result)} chars.")
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Gemini reasoning failed: {e}")
+
     # ── Internal ──────────────────────────────────────────────────────────────
 
     def _configure(self) -> None:

--- a/voice/speaker.py
+++ b/voice/speaker.py
@@ -78,10 +78,61 @@ def _clean_for_speech(text: str) -> str:
     return text
 
 
+def _split_into_sentences(text: str, max_chunk: int = 300) -> list[str]:
+    """Split text into speakable sentence chunks for Piper TTS.
+
+    Splits at sentence boundaries to produce natural speech rhythm.
+    Chunks exceeding max_chunk characters are split at the nearest
+    comma or clause boundary to prevent timeout issues.
+
+    Args:
+        text: Full response text to split.
+        max_chunk: Maximum characters per chunk before forced split.
+
+    Returns:
+        List of sentence strings ready for sequential TTS synthesis.
+    """
+    # Split on sentence-ending punctuation
+    raw = re.split(r'(?<=[.!?])\s+', text.strip())
+    chunks = []
+    current = ""
+
+    for sentence in raw:
+        if len(current) + len(sentence) <= max_chunk:
+            current += (" " if current else "") + sentence
+        else:
+            if current:
+                chunks.append(current.strip())
+            # If single sentence is too long, split at comma
+            if len(sentence) > max_chunk:
+                sub = re.split(r'(?<=,)\s+', sentence)
+                sub_chunk = ""
+                for part in sub:
+                    if len(sub_chunk) + len(part) <= max_chunk:
+                        sub_chunk += (" " if sub_chunk else "") + part
+                    else:
+                        if sub_chunk:
+                            chunks.append(sub_chunk.strip())
+                        sub_chunk = part
+                if sub_chunk:
+                    chunks.append(sub_chunk.strip())
+                current = ""
+            else:
+                current = sentence
+
+    if current:
+        chunks.append(current.strip())
+
+    return [c for c in chunks if c.strip()]
+
+
 def speak(text: str) -> None:
     """Synthesise text to speech and play it via sounddevice.
 
-    Strips markdown formatting and speaks the full response.
+    Long responses are split into sentence chunks and spoken
+    sequentially to prevent TTS timeout and mid-sentence cut-off.
+    Markdown is stripped before synthesis.
+
     Updates avatar state to 'speaking' during playback with
     amplitude-synced lip movement, then back to 'idle' when finished.
     Falls back to terminal print if TTS or playback fails.
@@ -92,12 +143,12 @@ def speak(text: str) -> None:
     if not text or not text.strip():
         return
 
-    # Warn on very long responses but still speak the full text
-    if len(text) > 1500:
-        print(f"[Aria] Long response ({len(text)} chars) — speaking full text.")
-
     # Strip markdown formatting before synthesis
     text = _clean_for_speech(text)
+    chunks = _split_into_sentences(text)
+
+    print(f"[Speaker] Speaking {len(chunks)} chunk(s), "
+          f"{len(text)} total chars.")
 
     # Update avatar state (imported here to avoid circular imports)
     try:
@@ -106,14 +157,16 @@ def speak(text: str) -> None:
     except ImportError:
         set_speaking = set_idle = set_amplitude = None
 
-    try:
-        _speak_sync(text)
-    except FileNotFoundError as e:
-        print(f"[Aria] ERROR: {e}")
-        print(f"[Aria] (text): {text}")
-    except Exception as e:
-        print(f"[Aria] ERROR: TTS failed — {e}")
-        print(f"[Aria] (text): {text}")
+    for i, chunk in enumerate(chunks):
+        try:
+            _speak_sync(chunk)
+        except FileNotFoundError as e:
+            print(f"[Speaker] ERROR on chunk {i+1}/{len(chunks)}: {e}")
+            print(f"[Speaker] (text): {chunk}")
+            break
+        except Exception as e:
+            print(f"[Speaker] ERROR on chunk {i+1}/{len(chunks)}: {e}")
+            print(f"[Speaker] (text): {chunk}")
 
     try:
         from avatar.renderer import set_idle, set_amplitude


### PR DESCRIPTION
## Summary
- **Gemini Flash promoted to primary Tier 2 reasoner** — all web search, weather, and general queries now go through a single multimodal Gemini call with web scrape text + desktop screenshot context
- **Ollama/Mistral becomes offline fallback** — controlled by `USE_LOCAL_FALLBACK` config toggle. Fallback chain: Gemini → Ollama → Claude (three-deep resilience)
- **TTS sentence splitting** — long responses are split at sentence boundaries and spoken sequentially, fixing cut-off on multi-sentence replies
- **Vision keyword expansion** — 10 new natural language variants ("can you see", "do you see", "look at this", etc.)
- **README updated** — phases 13-15 marked Complete, tech stack reflects new architecture

## Files changed
| File | Change |
|------|--------|
| `core/brain.py` | Rewrite `_handle_web_query()` for Gemini primary, add `_handle_ollama_fallback()`, `USE_LOCAL_FALLBACK` guard on vision |
| `core/vision_analyzer.py` | Add `reason_with_context()` — unified multimodal Tier 2 method |
| `core/router.py` | Expand vision keywords, update Tier 2 log messages |
| `voice/speaker.py` | Add `_split_into_sentences()`, refactor `speak()` to iterate chunks |
| `config.example.py` | Add `USE_LOCAL_FALLBACK = False` toggle with documentation |
| `README.md` | Update phase table (13-15 Complete) + tech stack |

## Test plan
- [x] Router: Weather → Tier 2 weather (Gemini path)
- [x] Router: New vision keywords all → Tier 2 vision
- [x] Router: Web search → Tier 2 web_search (Gemini path)
- [x] Router: Complex query → Tier 3 Claude
- [x] Router: Time → Tier 1 local
- [x] brain.py imports cleanly with `USE_LOCAL_FALLBACK`
- [x] Mood tag parsing works with and without tags
- [x] `VisionAnalyzer.reason_with_context()` method exists
- [x] Sentence splitting produces chunks ≤ 300 chars
- [x] `_query_ollama()` only called from `_handle_ollama_fallback()`

Closes #34, closes #35, closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)