### PR TITLE
fix: harden _parse_mood_tag so bracket prefixes never reach TTS

### DIFF
--- a/core/brain.py
+++ b/core/brain.py
@@ -177,10 +177,19 @@ _VALID_MOODS = {"HAPPY", "NEUTRAL", "THINKING", "SURPRISED", "SAD"}
 def _parse_mood_tag(text: str) -> tuple[str, str]:
     """Extract and validate a mood tag from an LLM response.
 
-    Parses a [MOOD] prefix from the response. If the tag isn't in the
-    defined valid set, silently returns NEUTRAL (still stripping the
-    bracketed prefix from the spoken text). This handles Ollama and
-    Mistral inventing their own tags despite the system prompt.
+    Parses a `[MOOD]` prefix from the response and ALWAYS strips the
+    bracketed prefix from the spoken text — even when the tag is
+    unknown or stylised — so brackets never reach TTS.
+
+    Tolerant of common Mistral/Claude formatting quirks:
+        - Mixed or lowercase tags: `[Neutral]`, `[neutral]`
+        - Markdown wrappers:       `**[NEUTRAL]**`
+        - Leading whitespace:      `\\n[NEUTRAL] hi`
+        - Plus signs / hyphens in tag names: `[VERY-HAPPY]`
+
+    If no recognisable bracket pattern is found at the start of the
+    text, the text is returned unchanged with NEUTRAL — the LLM simply
+    forgot the tag, but there's nothing to strip.
 
     Args:
         text: Raw LLM response potentially starting with [MOOD_TAG].
@@ -191,16 +200,27 @@ def _parse_mood_tag(text: str) -> tuple[str, str]:
 
     Examples:
         '[HAPPY] Hello Chan!'    -> ('HAPPY',   'Hello Chan!')
+        '[Neutral] hello'        -> ('NEUTRAL', 'hello')
+        '**[NEUTRAL]** hi'       -> ('NEUTRAL', 'hi')
         '[SORRY] My apologies'   -> ('NEUTRAL', 'My apologies')
         'No tag here'            -> ('NEUTRAL', 'No tag here')
     """
-    match = re.match(r'^\[([A-Z]+)\]\s*', text)
+    # Allow leading whitespace, optional markdown bold/italic wrappers,
+    # and ANY bracketed content — the _VALID_MOODS check decides whether
+    # to fire a hotkey, but we always strip the bracket from spoken text
+    # so TTS never reads "[NEUTRAL]" literally aloud.
+    match = re.match(r'^\s*[*_]{0,3}\[([^\]\n]+)\][*_]{0,3}\s*', text)
     if match:
-        tag   = match.group(1).upper()
-        clean = text[match.end():]
+        # Extract a tag word for the whitelist check: take the last
+        # alphabetic token inside the brackets (handles "Mood: Neutral").
+        raw_tag = match.group(1)
+        tokens  = re.findall(r'[A-Za-z]+', raw_tag)
+        tag     = tokens[-1].upper() if tokens else ""
+        clean   = text[match.end():]
         if tag in _VALID_MOODS:
             return tag, clean
-        # Unknown tag — strip bracketed prefix from spoken text, default to NEUTRAL silently
+        # Unknown / no recognisable tag — strip bracketed prefix anyway,
+        # default to NEUTRAL silently so brackets never reach TTS.
         return "NEUTRAL", clean
     return "NEUTRAL", text
 


### PR DESCRIPTION
## Summary

Fixes the symptom Chan reported (Aria saying \"NEUTRAL\" aloud) but with a different diagnosis than originally guessed.

## Diagnosis

Both `_handle_ollama_fallback` (line 523) and `_handle_claude` (lines 617, 622) **already invoke** `_parse_mood_tag`. The literal "missing call site" guess was wrong.

The actual bug is the regex inside `_parse_mood_tag`:

```python
match = re.match(r'^\[([A-Z]+)\]\s*', text)
```

This **fails to match** when the LLM returns any of these realistic variants — and on a non-match, the code returns the original text **with brackets intact**, which then goes straight to `speaker.py`:

| Input | Old behaviour |
|-------|---------------|
| `[Neutral] hello` | brackets reach TTS (mixed case) |
| `[neutral] hello` | brackets reach TTS (lower case) |
| `**[NEUTRAL]** hi` | brackets reach TTS (markdown wrapper) |
| `[Mood: NEUTRAL] x` | brackets reach TTS (label prefix) |
| `[VERY-HAPPY] excited` | brackets reach TTS (compound tag) |

## Fix

New regex: `^\s*[*_]{0,3}\[([^\]\n]+)\][*_]{0,3}\s*`

- Allows leading whitespace
- Allows optional markdown bold/italic wrappers
- Allows **any non-bracket content** inside the brackets

The `_VALID_MOODS` whitelist still gates the avatar hotkey trigger (extracts the last alphabetic token from the bracket contents — so `Mood: NEUTRAL` → NEUTRAL, `VERY-HAPPY` → HAPPY). When validation fails, the bracketed prefix is **still stripped** from spoken text, so brackets reach TTS in **zero cases** now.

## Test results — 16/16 PASS

```
[HAPPY] Hello Chan!         -> ('HAPPY',   'Hello Chan!')
[Neutral] hello             -> ('NEUTRAL', 'hello')
[neutral] hello             -> ('NEUTRAL', 'hello')
**[NEUTRAL]** hi            -> ('NEUTRAL', 'hi')
*[HAPPY]* hello             -> ('HAPPY',   'hello')
[SORRY] My apologies        -> ('NEUTRAL', 'My apologies')
No tag here                 -> ('NEUTRAL', 'No tag here')
  [HAPPY]  hello            -> ('HAPPY',   'hello')
\n[NEUTRAL] hi             -> ('NEUTRAL', 'hi')
[VERY-HAPPY] excited!       -> ('HAPPY',   'excited!')
[mood: neutral] x           -> ('NEUTRAL', 'x')
[Mood: NEUTRAL] response    -> ('NEUTRAL', 'response')
Sure! [NEUTRAL] hi          -> ('NEUTRAL', 'Sure! [NEUTRAL] hi')   ← unchanged: not at start
''                          -> ('NEUTRAL', '')
[HAPPY]hello                -> ('HAPPY',   'hello')
[123] no letters            -> ('NEUTRAL', 'no letters')
```

The `Sure! [NEUTRAL] hi` case intentionally stays unchanged — when the bracket isn't at the start of the message, it's likely real content (e.g. quoting), not a mood prefix.

## Files modified

- `core/brain.py` — `_parse_mood_tag()` regex hardened (~20 lines), no other changes

## Manual test (Chan)

After merge, trigger an Ollama fallback (`USE_LOCAL_FALLBACK=True`) and confirm Aria never speaks the word "neutral" or "happy" aloud regardless of how Mistral formats its mood tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)