### PR TITLE
feat: Stage 3a Proactive Analyst Loop — Aria observes and speaks unprompted

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,9 +256,11 @@ On first run:
 | 12 | VTube Studio hotkeys — Hiyori_A mood expressions | ✅ |
 | 13 | Gemini unified Tier 2 — web + screen multimodal | ✅ |
 | 14 | Kokoro-82M TTS | ⏸ Deferred — Python 3.13 incompatibility |
-| 15 | Stage 3 — proactive gameplay commentary | 🔄 Planned |
-| 16 | Memory upgrade — FAISS semantic search | 🔄 Planned |
-| 17 | Voice recognition training | 🔄 Planned |
+| 15 | Stage 3a — Proactive Analyst Loop | ✅ Complete |
+| 16 | Stage 3b — Notification state + queued insights | 🔄 Planned |
+| 17 | Stage 3c — Finance specialisation | 🔄 Planned |
+| 18 | Memory upgrade — FAISS semantic search | 🔄 Planned |
+| 19 | Voice recognition training | 🔄 Planned |
 
 ---
 

--- a/core/brain.py
+++ b/core/brain.py
@@ -343,6 +343,8 @@ def think(user_input: str) -> str:
             response = handle_date()
         elif intent == "calendar":
             response = handle_calendar()
+        elif intent == "analysis_mode":
+            response = _handle_analysis_toggle(user_input)
         else:
             response = handle_time()  # fallback
 
@@ -365,6 +367,47 @@ def think(user_input: str) -> str:
     store_episodic("aria", response)
     record_interaction()
     return response
+
+
+# ── Tier 1 — analysis mode toggle ─────────────────────────────────────────────
+
+def _handle_analysis_toggle(text: str) -> str:
+    """Handle the proactive-analysis mode toggle command.
+
+    Routes to the global ProactiveAnalyst instance owned by main.py.
+    The analyst speaks its own confirmation aloud — this handler returns
+    an empty string so think() doesn't double-speak.
+
+    Args:
+        text: The user's original query (used to detect on/off intent).
+
+    Returns:
+        Empty string on success — analyst speaks its own confirmation.
+        A short error string only if the analyst module is unreachable.
+    """
+    text_lower = text.lower()
+    on_keywords  = ("on", "enable", "start", "activate")
+    off_keywords = ("off", "disable", "stop", "deactivate")
+
+    try:
+        # main is imported lazily to avoid a circular import at module load.
+        from main import _proactive_analyst
+        if _proactive_analyst is None:
+            return "The analyst module isn't running, Chan."
+
+        if any(kw in text_lower for kw in on_keywords):
+            _proactive_analyst.enable()
+        elif any(kw in text_lower for kw in off_keywords):
+            _proactive_analyst.disable()
+        else:
+            _proactive_analyst.toggle()
+
+    except ImportError:
+        return "I couldn't reach the analyst module, Chan."
+    except Exception as e:
+        print(f"[Brain] Analysis toggle error: {e}")
+
+    return ""  # Analyst speaks its own confirmation
 
 
 # ── Tier 2 handler ────────────────────────────────────────────────────────────

--- a/core/proactive_analyst.py
+++ b/core/proactive_analyst.py
@@ -1,0 +1,297 @@
+"""
+core/proactive_analyst.py
+-------------------------
+Stage 3a: Proactive Analyst Loop for Aria.
+
+Runs as a background daemon thread. Every 60 seconds, reads the latest
+desktop screenshot and sends it to Gemini with an insight-filtering prompt.
+
+Response handling:
+    'IDLE'        → do nothing, stay silent
+    anything else → speak the insight via the voice pipeline
+
+Design principles:
+    - IDLE is the default. Gemini must be highly confident to return insight.
+    - 5-minute cooldown prevents Aria from being intrusive.
+    - Analysis mode defaults to OFF — user opts in via voice command.
+    - Thread is non-blocking — voice pipeline operates independently.
+
+Stage roadmap:
+    3a (this):  Direct speech, general desktop context
+    3b (future): Notification state — N05 alert, queued insights
+    3c (future): Finance specialisation — tickers, sentiment, SEC filings
+"""
+
+from __future__ import annotations
+
+import io
+import threading
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Callable, Optional
+
+LATEST_SCREENSHOT  = Path("data/captures/latest.png")
+ANALYSIS_INTERVAL  = 60          # Seconds between analysis cycles
+COOLDOWN_MINUTES   = 5           # Minimum minutes between proactive comments
+MAX_SCREENSHOT_AGE = 90          # Seconds — skip if latest.png is too stale
+
+# Use the same Gemini model as vision_analyzer.py for consistency.
+# Override via config.GEMINI_MODEL if needed.
+DEFAULT_GEMINI_MODEL = "gemini-2.5-flash"
+
+# Gemini prompt — negatively reinforced, IDLE is the default response
+ANALYST_PROMPT = """You are Aria, an observant AI desktop assistant for Chan.
+
+Review this desktop screenshot carefully.
+
+Your job is to identify HIGH-VALUE insights only. You must be at least 80% confident
+the insight is genuinely useful before returning it.
+
+Return IDLE (and nothing else) if:
+- The screen looks normal and there is nothing actionable to flag
+- You are just describing what you see with no insight attached
+- You have low confidence about what is on screen
+- The screen has not changed significantly from a typical working state
+
+Return a 1-2 sentence spoken insight ONLY if you observe:
+- An error message, warning, or failed process the user may have missed
+- A logical inconsistency, contradiction, or potential mistake in visible work
+- A pattern, trend, or correlation across multiple visible sources
+- A complex problem on screen where a quick observation could save time
+- Something that directly requires the user's attention right now
+
+If returning an insight, write it as Aria would speak it — concise, direct,
+addressed to Chan. Do not use markdown. Do not prefix with IDLE.
+
+Your response must be either exactly 'IDLE' or a 1-2 sentence spoken insight.
+Nothing else."""
+
+
+class ProactiveAnalyst:
+    """Background analyst that monitors the desktop and speaks unprompted.
+
+    Reads latest.png on a 60-second cycle and sends it to Gemini with
+    a strict insight-filtering prompt. Only non-IDLE responses are spoken.
+
+    Attributes:
+        enabled: Whether analysis mode is currently active.
+        running: Whether the background thread is alive.
+        last_comment_time: Timestamp of the last proactive comment spoken.
+    """
+
+    def __init__(
+        self,
+        speak_fn: Callable[[str], None],
+        set_state_fn: Callable[[str], None],
+        trigger_mood_fn: Callable[[str], None],
+    ) -> None:
+        """Initialise the proactive analyst.
+
+        Args:
+            speak_fn: Callable — the speak() function from voice/speaker.py.
+                      Called to deliver proactive insights aloud.
+            set_state_fn: Callable taking a state name ('idle', 'thinking', etc.).
+                          Forwards to the avatar renderer's state setter.
+            trigger_mood_fn: Callable taking a mood tag (e.g. 'THINKING')
+                             which fires a VTS hotkey via vts_controller.
+        """
+        self._speak        = speak_fn
+        self._set_state    = set_state_fn
+        self._trigger_mood = trigger_mood_fn
+
+        self.enabled: bool                       = False  # OFF by default
+        self.running: bool                       = False
+        self.last_comment_time: Optional[datetime] = None
+
+        self._thread: Optional[threading.Thread] = None
+        self._lock                               = threading.Lock()
+
+        # Initialise Gemini client lazily — None means analysis disabled
+        self._client: object | None = None
+        self._model_name: str       = DEFAULT_GEMINI_MODEL
+        self._init_gemini()
+
+    def _init_gemini(self) -> None:
+        """Initialise the Gemini client.
+
+        Uses the same SDK pattern as vision_analyzer.py
+        (`from google import genai; genai.Client(api_key=...)`).
+        Sets self._client to None on any failure — the analyst then
+        runs but cycles produce no output.
+        """
+        try:
+            from google import genai
+            import config
+
+            api_key = getattr(config, "GEMINI_API_KEY", "") or ""
+            if not api_key or api_key.startswith("your-"):
+                print("[Analyst] WARNING: GEMINI_API_KEY not set — proactive analysis disabled.")
+                return
+
+            self._client     = genai.Client(api_key=api_key)
+            self._model_name = getattr(config, "GEMINI_MODEL", DEFAULT_GEMINI_MODEL)
+            print(f"[Analyst] Gemini ready — model: {self._model_name}")
+        except ImportError:
+            print("[Analyst] WARNING: google-genai not installed — proactive analysis disabled.")
+        except Exception as e:
+            print(f"[Analyst] ERROR: Could not initialise Gemini — {e}")
+
+    # ── Public control ────────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """Start the background analyst thread.
+
+        Safe to call multiple times — will not start a second thread.
+        """
+        if self.running:
+            return
+        self.running = True
+        self._thread = threading.Thread(
+            target=self._loop,
+            daemon=True,
+            name="ProactiveAnalystThread",
+        )
+        self._thread.start()
+        print(
+            f"[Analyst] Proactive analyst started — "
+            f"{ANALYSIS_INTERVAL}s cycle, {COOLDOWN_MINUTES}min cooldown. "
+            f"Analysis mode: OFF (say 'Aria, analysis mode on' to enable)."
+        )
+
+    def stop(self) -> None:
+        """Stop the analyst thread gracefully."""
+        self.running = False
+        print("[Analyst] Proactive analyst stopped.")
+
+    def enable(self) -> None:
+        """Enable analysis mode — Aria will speak proactive insights."""
+        with self._lock:
+            self.enabled = True
+        print("[Analyst] Analysis mode: ON")
+        self._speak("Analysis mode on, Chan. I'll let you know if I spot anything worth flagging.")
+
+    def disable(self) -> None:
+        """Disable analysis mode — Aria stays silent proactively."""
+        with self._lock:
+            self.enabled = False
+        print("[Analyst] Analysis mode: OFF")
+        self._speak("Analysis mode off, Chan. I'll stay quiet unless you ask me something.")
+
+    def toggle(self) -> bool:
+        """Toggle analysis mode on or off.
+
+        Returns:
+            True if now enabled, False if now disabled.
+        """
+        if self.enabled:
+            self.disable()
+            return False
+        self.enable()
+        return True
+
+    # ── Internal loop ─────────────────────────────────────────────────────────
+
+    def _loop(self) -> None:
+        """Main analysis loop — runs in background daemon thread.
+
+        Sleeps for ANALYSIS_INTERVAL seconds between cycles.
+        Skips analysis if disabled, on cooldown, or screenshot is stale.
+        Never raises — exceptions are logged and the loop continues.
+        """
+        while self.running:
+            try:
+                time.sleep(ANALYSIS_INTERVAL)
+
+                if not self.enabled:
+                    continue
+
+                if self._on_cooldown():
+                    remaining = self._cooldown_remaining()
+                    print(f"[Analyst] On cooldown — {remaining:.0f}s remaining.")
+                    continue
+
+                if not self._screenshot_fresh():
+                    print("[Analyst] Screenshot too stale — skipping cycle.")
+                    continue
+
+                self._analyse()
+
+            except Exception as e:
+                print(f"[Analyst] ERROR in analysis loop: {e}")
+                # Never crash the thread
+
+    def _analyse(self) -> None:
+        """Run one analysis cycle — read screenshot, query Gemini, speak if insight."""
+        if self._client is None:
+            return
+
+        print("[Analyst] Running analysis cycle...")
+
+        try:
+            # Signal avatar is thinking
+            self._set_state("thinking")
+
+            # Read latest.png as raw bytes (defensive: catch partial writes)
+            image_bytes = LATEST_SCREENSHOT.read_bytes()
+            if len(image_bytes) < 1024:
+                print(f"[Analyst] Screenshot too small ({len(image_bytes)} bytes) — likely partial write, skipping.")
+                self._set_state("idle")
+                return
+
+            # Decode via PIL — same pattern vision_analyzer uses, plays well with Gemini SDK
+            from PIL import Image
+            img = Image.open(io.BytesIO(image_bytes))
+            img.load()  # force decode now so any truncation surfaces here
+
+            response = self._client.models.generate_content(
+                model=self._model_name,
+                contents=[ANALYST_PROMPT, img],
+            )
+
+            result = (getattr(response, "text", "") or "").strip()
+            if not result:
+                print("[Analyst] Empty Gemini response — treating as IDLE.")
+                self._set_state("idle")
+                return
+
+            print(f"[Analyst] Gemini response: {result[:80]!r}")
+
+            # IDLE — stay silent (handle bare 'IDLE' or 'IDLE.' or 'IDLE\n' etc.)
+            if result.upper().startswith("IDLE"):
+                print("[Analyst] IDLE — no insight to share.")
+                self._set_state("idle")
+                return
+
+            # Non-IDLE — speak the insight
+            print(f"[Analyst] Insight detected — speaking ({len(result)} chars).")
+            self.last_comment_time = datetime.now()
+            self._trigger_mood("THINKING")
+            self._speak(result)
+            self._set_state("idle")
+
+        except Exception as e:
+            print(f"[Analyst] ERROR during analysis: {e}")
+            self._set_state("idle")
+
+    # ── Helpers ───────────────────────────────────────────────────────────────
+
+    def _on_cooldown(self) -> bool:
+        """Return True if Aria should not make a proactive comment yet."""
+        if self.last_comment_time is None:
+            return False
+        return datetime.now() - self.last_comment_time < timedelta(minutes=COOLDOWN_MINUTES)
+
+    def _cooldown_remaining(self) -> float:
+        """Return seconds remaining on the cooldown."""
+        if self.last_comment_time is None:
+            return 0.0
+        elapsed = (datetime.now() - self.last_comment_time).total_seconds()
+        return max(0.0, (COOLDOWN_MINUTES * 60) - elapsed)
+
+    def _screenshot_fresh(self) -> bool:
+        """Return True if latest.png is under MAX_SCREENSHOT_AGE seconds old."""
+        if not LATEST_SCREENSHOT.exists():
+            return False
+        age = time.time() - LATEST_SCREENSHOT.stat().st_mtime
+        return age < MAX_SCREENSHOT_AGE

--- a/core/router.py
+++ b/core/router.py
@@ -53,6 +53,14 @@ INTENT_MAP: dict[str, dict] = {
             "what's on today", "agenda",
         ],
     },
+    "analysis_mode": {
+        "tier": 1,
+        "keywords": [
+            "analysis mode on",  "enable analysis",  "start analysis",
+            "analysis mode off", "disable analysis", "stop analysis",
+            "analysis mode",     "toggle analysis",
+        ],
+    },
 
     # Tier 2 — web + Ollama, free
     "weather": {

--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ from avatar.renderer import (
 )
 from voice.trainer import run_calibration, get_profile_summary
 from core.screen_capture import ScreenCapture
+from core.proactive_analyst import ProactiveAnalyst
 
 # Name variants Whisper might produce (case-insensitive matching)
 # Expanded for large-v2 + British accent phonetic variants
@@ -124,6 +125,45 @@ def toggle_free_conversation() -> bool:
 
 # ── Module-level screen capture instance ──────────────────────────
 _screen_capture: ScreenCapture | None = None
+
+# ── Module-level proactive analyst instance (Stage 3a) ────────────
+# Accessed by core.brain._handle_analysis_toggle to flip analysis mode
+# from a voice command. Stays None if Gemini isn't configured.
+_proactive_analyst: ProactiveAnalyst | None = None
+
+
+def _analyst_set_state(state: str) -> None:
+    """Forward a state-name string to the avatar renderer's setter.
+
+    Used by ProactiveAnalyst — keeps the analyst module decoupled from
+    the renderer's state-specific function names.
+
+    Args:
+        state: One of 'idle', 'listening', 'thinking', 'speaking', 'dormant'.
+    """
+    if state == "idle":
+        set_idle()
+    elif state == "thinking":
+        set_thinking()
+    elif state == "listening":
+        set_listening()
+    elif state == "dormant":
+        set_dormant()
+    # 'speaking' is handled inside speak() — analyst doesn't need to fire it
+
+
+def _analyst_trigger_mood(mood: str) -> None:
+    """Trigger a VTS mood hotkey from the analyst, if VTS is connected.
+
+    Args:
+        mood: Mood tag (e.g. 'THINKING', 'HAPPY').
+    """
+    try:
+        from avatar.renderer import _controller
+        if _controller:
+            _controller.trigger_mood(mood)
+    except Exception:
+        pass  # VTS not connected — continue silently
 
 
 def print_banner():
@@ -323,6 +363,8 @@ def voice_pipeline(device_index: int | None, avatar) -> None:
         shutdown_scheduler()
         if _screen_capture:
             _screen_capture.stop()
+        if _proactive_analyst:
+            _proactive_analyst.stop()
         avatar.close()
 
 
@@ -380,6 +422,21 @@ def run_aria():
 
     # Create avatar (connects to VTube Studio in background)
     avatar = create_avatar(on_mode_toggle=toggle_conversation_mode)
+
+    # Initialise proactive analyst (Stage 3a)
+    # Defaults to OFF — user opts in via "Aria, analysis mode on".
+    global _proactive_analyst
+    try:
+        _proactive_analyst = ProactiveAnalyst(
+            speak_fn=speak,
+            set_state_fn=_analyst_set_state,
+            trigger_mood_fn=_analyst_trigger_mood,
+        )
+        _proactive_analyst.start()
+    except Exception as e:
+        print(f"[Analyst] WARNING: Could not start proactive analyst — {e}")
+        _proactive_analyst = None
+    print()
 
     # Launch voice pipeline in a background thread
     pipeline_thread = threading.Thread(


### PR DESCRIPTION
## Summary

Stage 3a infrastructure: Aria monitors the desktop every 60s via Gemini Flash vision and speaks unprompted when she detects a high-value insight. Toggleable via voice. Defaults to OFF — opt-in.

## Closes
- Closes #56

## Architecture

```
ScreenCapture (5s loop, existing)  →  data/captures/latest.png
                                              │
                                              ▼ (every 60s when enabled)
                                  ProactiveAnalyst._loop
                                              │
                                              ▼
                                  Gemini Flash + ANALYST_PROMPT
                                              │
                                              ▼
                                  IDLE? ───── Yes ──→ silent, set_idle
                                  │
                                  No
                                  │
                                  ▼
                          speak() + 5min cooldown set
```

## Voice control
- "Aria, analysis mode on" → enable, Aria confirms aloud
- "Aria, analysis mode off" → disable, Aria confirms aloud
- "Aria, toggle analysis" → flip current state

Routed via new Tier 1 `analysis_mode` intent in `core/router.py`.

## Files

| File | Change |
|------|--------|
| `core/proactive_analyst.py` | **NEW** — ProactiveAnalyst class, 60s daemon loop, IDLE filter, 5min cooldown, opt-in toggle |
| `core/router.py` | New `analysis_mode` Tier 1 intent (8 keyword variants) |
| `core/brain.py` | `_handle_analysis_toggle()` — routes intent to global analyst, returns `""` so think() doesn't double-speak |
| `main.py` | Imports + starts ProactiveAnalyst after avatar creation, stops in finally block. Adds `_analyst_set_state` and `_analyst_trigger_mood` callback wrappers |
| `README.md` | Phase 15 = Stage 3a Complete; new phases 16-19 for Stage 3b/3c, FAISS, voice training |

## Adaptations from spec

- **Gemini model** — used `gemini-2.5-flash` (matches `vision_analyzer.py`) instead of spec's `gemini-2.0-flash` default. Project doesn't use 2.0 anywhere.
- **Screenshot decode** — used PIL `Image.open(BytesIO).load()` instead of spec's `genai_types.Part.from_bytes()`. Same defensive pattern as `vision_analyzer._load_screenshot` post-PR #50: bytes-buffer it, force-decode to surface truncation locally rather than inside the Gemini SDK. Plays well with the SDK's PIL-image content support.
- **State callback** — created small `_analyst_set_state(state: str)` wrapper in main.py that maps state strings to the existing `set_idle/thinking/listening/dormant` functions. Keeps the analyst decoupled from renderer internals.

## Test results — 18/18 PASS

```
Imports clean:               core.proactive_analyst, router, brain, main ✓
Router classification:       8/8 — all analysis_mode keyword variants → Tier 1
                                   time, vision unaffected
Analyst lifecycle:
  Defaults to disabled (opt-in)                                       ✓
  Not running before start()                                          ✓
  enable() flips state + speaks confirmation                          ✓
  disable() flips state + speaks confirmation                         ✓
  toggle() returns new state correctly                                ✓
  cooldown active immediately after comment (300s remaining)          ✓
  cooldown clears after COOLDOWN_MINUTES                              ✓
  no cooldown if never commented                                      ✓
Brain wiring:
  analyst None returns helpful "isn't running" message                ✓
  "on" → enable(), empty return                                       ✓
  "off" → disable()                                                   ✓
  ambiguous "toggle" → toggle()                                       ✓
```

## MANUAL TESTS REQUIRED — Chan, after merge

Live tests need `python main.py` + VTube Studio + Gemini API:

| # | Action | Expected |
|---|--------|----------|
| 1 | Start Aria | `[Analyst] Gemini ready` + `Proactive analyst started — 60s cycle, 5min cooldown. Analysis mode: OFF` |
| 2 | "Aria, analysis mode on" | `[Analyst] Analysis mode: ON` + Aria speaks confirmation |
| 3 | Wait 60s on idle desktop | `[Analyst] Gemini response: 'IDLE'` → silent |
| 4 | Open visible content (page with errors/text) | Gemini may return non-IDLE → spoken |
| 5 | Within 5min of any spoken insight | `[Analyst] On cooldown — XXXs remaining.` |
| 6 | "Aria, analysis mode off" | Aria confirms, subsequent cycles silent |
| 7 | "Aria, what time is it?" mid-loop | Voice pipeline responds immediately, analysis loop unaffected |

## Roadmap (in README)

- **Stage 3b** — notification state + queued insights (N05 alert hotkey, queue replaces direct speak)
- **Stage 3c** — finance specialisation (tickers, sentiment, SEC filings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)