### PR TITLE
fix: ProactiveAnalyst unreachable from brain.py — sys.modules main/__main__ alias

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,6 +20,17 @@ Usage:
 
 import sys
 import threading
+
+# When Aria is launched via `python main.py`, this script is registered in
+# sys.modules as '__main__' only. core.brain._handle_analysis_toggle does
+# `from main import _proactive_analyst`, which would otherwise force Python
+# to re-import main.py as a SECOND, separate `main` module — with all the
+# top-level state freshly re-initialised (so `_proactive_analyst = None`).
+# Aliasing __main__ → 'main' here means both names resolve to the same
+# module object, so brain.py sees the live analyst instance.
+if __name__ == "__main__":
+    sys.modules.setdefault("main", sys.modules[__name__])
+
 from voice.listener import record_audio, get_audio_devices, calibrate_silence
 from voice.transcriber import load_model, transcribe_audio
 from voice.wake import listen_for_wake_word
@@ -433,8 +444,14 @@ def run_aria():
             trigger_mood_fn=_analyst_trigger_mood,
         )
         _proactive_analyst.start()
+        # Definitive confirmation — if this line appears, the analyst object
+        # exists, the daemon thread is running, and brain.py can reach it.
+        print("[Analyst] Startup confirmed.")
     except Exception as e:
-        print(f"[Analyst] WARNING: Could not start proactive analyst — {e}")
+        # Loud and unambiguous so the line cannot be lost in startup noise.
+        print(f"[Analyst] FAILED to start: {e}")
+        import traceback
+        traceback.print_exc()
         _proactive_analyst = None
     print()
 


### PR DESCRIPTION
## TL;DR

Root cause was NOT a missing startup call. Every checklist item Chan asked me to verify was already correct from PR #57:

| Check | Result |
|---|---|
| `from core.proactive_analyst import ProactiveAnalyst` at top | ✅ line 40 |
| `_proactive_analyst = ProactiveAnalyst(...)` during startup | ✅ line 430-434 |
| `_proactive_analyst.start()` called | ✅ line 435 |
| `_proactive_analyst` declared at module level | ✅ line 132 |
| try/except print (visibility) | ⚠️ said "WARNING:" not "FAILED:" — improved here |

The bug is **how the analyst is reached, not how it starts.**

## Root cause — Python dual-module import

When you run `python main.py`, the script registers in `sys.modules` only as `__main__`. `_proactive_analyst` (the live instance) lives on the `__main__` module.

In `core/brain.py`, `_handle_analysis_toggle` does:

```python
from main import _proactive_analyst
```

Python doesn't find `main` in sys.modules → re-imports `main.py` as a **separate, fresh module**. That re-execution runs every top-level statement, including:

```python
_proactive_analyst: ProactiveAnalyst | None = None  # line 132
```

The `if __name__ == "__main__"` block doesn't fire in the second copy, so `run_aria()` never runs there. The new `main` module's `_proactive_analyst` stays `None`.

**Result:** brain.py always sees `None`, Aria always says *"The analyst module isn't running, Chan."* — even when the daemon thread is happily running on `__main__`. That's the symptom Chan reported.

## Verified with a controlled import test

```python
WITH alias:    brain.py would see: 'LIVE_INSTANCE'
WITHOUT alias: WITHOUT alias, fresh import gives: None
```

Same code path. Same module name. Different result. The alias is the fix.

## Fix

```python
if __name__ == "__main__":
    sys.modules.setdefault("main", sys.modules[__name__])
```

One line. Aliases `__main__` ↔ `main` so both names resolve to the same module object. brain.py's `from main import _proactive_analyst` now returns the live instance.

## Plus the diagnostic prints Chan asked for

- `[Analyst] Startup confirmed.` after `_proactive_analyst.start()` — if Chan sees this, the analyst object exists, daemon thread is running, brain can reach it.
- `[Analyst] FAILED to start: <error>` (replaces the old `WARNING:`) in the except, with `traceback.print_exc()` — actual exceptions can never be silently buried again.

## Files

`main.py` only (18 insertions, 1 deletion). No other files touched per instruction.

## Manual test (Chan, after merge)

1. Start Aria — terminal shows `[Analyst] Gemini ready` + `[Analyst] Proactive analyst started — 60s cycle...` + **`[Analyst] Startup confirmed.`** (the new line)
2. Say "Aria, analysis mode on" — should now correctly toggle to ON. Aria speaks the confirmation. Previously this returned "isn't running, Chan." — that's the bug fix.
3. Say "Aria, analysis mode off" — confirms off.
4. If startup ever fails: terminal shows `[Analyst] FAILED to start: <message>` + a full traceback, no more silent failure.

## Note for future cleanup

The `sys.modules` alias is the correct pragmatic fix here, but it's worth eventually replacing the `from main import _proactive_analyst` pattern. A cleaner long-term approach: expose the analyst via a module-level getter on `core.proactive_analyst` itself (e.g. `set_instance()` / `get_instance()`), so `brain.py` never needs to reach into `main.py`. That eliminates the entire dual-import surface area. Out of scope here per single-file constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)