### PR TITLE
fix: analyst confirmation print + vision productivity keywords

### DIFF
--- a/core/proactive_analyst.py
+++ b/core/proactive_analyst.py
@@ -165,18 +165,31 @@ class ProactiveAnalyst:
         print("[Analyst] Proactive analyst stopped.")
 
     def enable(self) -> None:
-        """Enable analysis mode — Aria will speak proactive insights."""
+        """Enable analysis mode — Aria will speak proactive insights.
+
+        Prints the spoken confirmation explicitly. The analyst speaks
+        via the injected speak_fn (bypassing the normal voice-pipeline
+        print path), so without this print the terminal shows a bare
+        '[Aria]' followed by a blank line.
+        """
         with self._lock:
             self.enabled = True
         print("[Analyst] Analysis mode: ON")
-        self._speak("Analysis mode on, Chan. I'll let you know if I spot anything worth flagging.")
+        confirmation = "Analysis mode on, Chan. I'll let you know if I spot anything worth flagging."
+        print(f"[Aria] {confirmation}")
+        self._speak(confirmation)
 
     def disable(self) -> None:
-        """Disable analysis mode — Aria stays silent proactively."""
+        """Disable analysis mode — Aria stays silent proactively.
+
+        Prints the spoken confirmation explicitly (see enable() for why).
+        """
         with self._lock:
             self.enabled = False
         print("[Analyst] Analysis mode: OFF")
-        self._speak("Analysis mode off, Chan. I'll stay quiet unless you ask me something.")
+        confirmation = "Analysis mode off, Chan. I'll stay quiet unless you ask me something."
+        print(f"[Aria] {confirmation}")
+        self._speak(confirmation)
 
     def toggle(self) -> bool:
         """Toggle analysis mode on or off.

--- a/core/router.py
+++ b/core/router.py
@@ -92,6 +92,13 @@ INTENT_MAP: dict[str, dict] = {
             "describe what you see", "see my screen",
             "looking at my screen", "what do you observe",
             "tell me what you see",
+            # Productivity and evaluation queries
+            "is this good", "is this a good", "evaluate what you see",
+            "what do you think of this", "review what you see", "review my screen",
+            "what do you make of this", "give me feedback", "is this correct",
+            "check this for me", "look at this and tell me",
+            "what do you think about what you see",
+            "does this look right", "any issues with this", "spot anything wrong",
         ],
     },
 


### PR DESCRIPTION
## Summary

Two small bug fixes packaged together. First of three sequential PRs in this sprint — Prompt 1 of 3.

## Closes
- Closes #59 (analyst confirmation prints to TTS but not to terminal)
- Closes #60 (productivity-style vision queries route to Claude instead of Gemini)

## Changes

| File | Change |
|------|--------|
| `core/proactive_analyst.py` | `enable()` and `disable()` now print `[Aria] <confirmation>` before `_speak()`. Bare `[Aria]\n` blank line is gone. |
| `core/router.py` | 15 new vision intent keywords for productivity / evaluation queries. |

## Programmatic test results

```
Vision keyword routing (#60):              13/13 PASS
Existing vision keywords still work:        5/5 PASS
Other intents unaffected (time/weather/…):  4/4 PASS
Analyst confirmation prints (#59):          4/4 PASS
```

## Notable spec discrepancy caught

The spec listed `"is this good"` but the spec's example query was `"is this a good dashboard on my screen?"`. The substring `"is this good"` is not present in `"is this a good"` (indefinite article in the way) — so the literal keyword would have failed Chan's own example test.

Added `"is this a good"` alongside `"is this good"` so both forms route correctly.

## Manual test (Chan, after merge)

1. Say "Aria, analysis mode on" — terminal now prints `[Aria] Analysis mode on, Chan. I'll let you know if I spot anything worth flagging.` (was blank before)
2. Say "Aria, is this a good dashboard on my screen?" — terminal shows `[Router] Tier 2 matched: vision`
3. Say "Aria, analysis mode off" — terminal prints the off confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)