### PR TITLE
Improve Tier 2 response quality

### DIFF
--- a/core/brain.py
+++ b/core/brain.py
@@ -242,28 +242,76 @@ def _trigger_avatar_mood(mood: str) -> None:
         pass  # Visual layer unavailable — continue silently
 
 
-def _ensure_complete_sentence(text: str) -> str:
-    """Append a period if a Tier 2 response ends mid-word.
+class IncompleteModelResponseError(ValueError):
+    """Raised when a model response is too incomplete to speak safely."""
 
-    Gemini occasionally returns truncated responses (slow API, content
-    filter mid-stream, partial stream). This guard catches the most
-    obvious case — text ending with no sentence-ending punctuation —
-    and appends a period so TTS doesn't speak a dangling fragment.
 
-    Does not fix the upstream Gemini truncation, just sands off the
-    rough edge so Aria sounds intentional rather than glitchy.
+_INCOMPLETE_TAIL_WORDS = {
+    "a", "an", "and", "are", "as", "at", "because", "but", "by", "for",
+    "from", "if", "in", "including", "into", "of", "on", "or", "so",
+    "that", "the", "to", "using", "via", "with",
+}
 
-    Args:
-        text: Cleaned response text (mood tag already stripped).
+_INCOMPLETE_TAIL_PATTERNS = (
+    r"\baccess to external$",
+    r"\bcapitalization for$",
+    r"\bmarket cap(?:italization)? of$",
+    r"\bcould(?:n't| not) find\b.+\bfor$",
+    r"\busing only the web information$",
+)
 
-    Returns:
-        Text guaranteed to end with sentence-closing punctuation.
+_DEFAULT_INCOMPLETE_RESPONSE = (
+    "I got an incomplete response back, Chan. Ask me to check that again "
+    "and I'll rerun it."
+)
+
+
+def _looks_incomplete_response(text: str) -> bool:
+    """Return True when a model response appears truncated mid-thought."""
+    stripped = text.strip()
+    if not stripped:
+        return True
+    if stripped[-1] in ".!?":
+        return False
+
+    lowered = stripped.lower().rstrip(",;:")
+    if any(re.search(pattern, lowered) for pattern in _INCOMPLETE_TAIL_PATTERNS):
+        return True
+
+    words = re.findall(r"[a-zA-Z']+", lowered)
+    return bool(words and words[-1] in _INCOMPLETE_TAIL_WORDS)
+
+
+def _ensure_complete_sentence(
+    text: str,
+    *,
+    source: str = "model",
+    strict: bool = False,
+    fallback_message: str = _DEFAULT_INCOMPLETE_RESPONSE,
+) -> str:
+    """Return speakable text, rejecting obviously incomplete model output.
+
+    Missing final punctuation is acceptable when the response otherwise looks
+    complete; Aria can append a period. Dangling fragments such as
+    "access to external" or "market capitalization for" are not acceptable
+    because they sound like runtime failures when spoken aloud.
     """
     if not text:
         return text
     text = text.rstrip()
     if text and text[-1] not in ".!?":
-        log.warning("Response ends mid-word — appending '.' to ...%r", text[-20:])
+        if _looks_incomplete_response(text):
+            log.warning(
+                "%s response rejected as incomplete: ...%r",
+                source,
+                text[-80:],
+            )
+            if strict:
+                raise IncompleteModelResponseError(
+                    f"{source} response appears incomplete"
+                )
+            return fallback_message
+        log.info("%s response missing final punctuation; appending period.", source)
         text += "."
     return text
 
@@ -671,11 +719,17 @@ def _handle_web_query(text: str, intent: str = "") -> str:
         )
         log.info("Gemini Tier 2 response — %d chars.", len(raw))
         mood, clean_response = _parse_mood_tag(raw)
-        clean_response = _ensure_complete_sentence(clean_response)
+        clean_response = _ensure_complete_sentence(
+            clean_response,
+            source="Gemini Tier 2",
+            strict=True,
+        )
         clean_response = _limit_spoken_response(clean_response, text)
         _trigger_avatar_mood(mood)
         return clean_response
 
+    except IncompleteModelResponseError as e:
+        log.warning("Gemini response failed quality gate (%s) — falling back to Ollama.", e)
     except Exception as e:
         log.warning("Gemini failed (%s) — falling back to Ollama.", e)
 
@@ -714,7 +768,14 @@ def _handle_vision(text: str) -> str:
     analyzer = _get_vision_analyzer()
     raw = analyzer.analyse_screen(context=text)
     mood, clean_response = _parse_mood_tag(raw)
-    clean_response = _ensure_complete_sentence(clean_response)
+    clean_response = _ensure_complete_sentence(
+        clean_response,
+        source="Gemini vision",
+        fallback_message=(
+            "I can see your screen, Chan, but my visual read came back "
+            "incomplete. Ask me to look again and I'll rerun it."
+        ),
+    )
     clean_response = _limit_spoken_response(clean_response, text)
     _trigger_avatar_mood(mood)
     return clean_response
@@ -801,7 +862,14 @@ def _handle_ollama_fallback(text: str, web_context: str = "") -> str:
         raw = _query_ollama(prompt)
         log.info("Ollama fallback response — %d chars.", len(raw))
         mood, clean_response = _parse_mood_tag(raw)
-        clean_response = _ensure_complete_sentence(clean_response)
+        clean_response = _ensure_complete_sentence(
+            clean_response,
+            source="Ollama fallback",
+            fallback_message=(
+                "I found some web context, Chan, but the generated answer "
+                "came back incomplete. Ask me to check again and I'll rerun it."
+            ),
+        )
         clean_response = _limit_spoken_response(clean_response, text)
         _trigger_avatar_mood(mood)
         return clean_response

--- a/core/web_search.py
+++ b/core/web_search.py
@@ -51,6 +51,12 @@ _CONVERSATIONAL_PREFIXES = (
     "search for ", "look up ", "find out ",
 )
 
+_CORRECTION_PREFIX_PATTERNS = (
+    r"^(?:no|nope|nah)[,\s]+",
+    r"^(?:actually|sorry|correction)[,\s]+",
+    r"^(?:i meant|i mean|what i meant was|what i mean is)[,\s]+",
+)
+
 # Common Whisper mishear corrections for command words.
 # Multi-word patterns ensure we only correct in command contexts —
 # bare "such" stays untouched ("such a good day" should not be modified),
@@ -89,17 +95,26 @@ def clean_query(raw: str) -> str:
     """
     text = raw.lower().strip().rstrip("?.,!")
 
-    # Strip Aria name variants from start
-    for prefix in sorted(_ARIA_PREFIXES, key=len, reverse=True):
-        if text.startswith(prefix):
-            text = text[len(prefix):].strip().lstrip(",").strip()
-            break
-
-    # Strip conversational prefixes — loop to catch chained filler
-    # e.g. "can you look up" → strip "can you " → strip "look up "
+    # Strip Aria name variants, corrections, and conversational prefixes.
+    # Loop to catch chained filler, e.g. "Aria, no, can you look up...".
     changed = True
     while changed:
         changed = False
+        for prefix in sorted(_ARIA_PREFIXES, key=len, reverse=True):
+            if text.startswith(prefix):
+                text = text[len(prefix):].strip().lstrip(",").strip()
+                changed = True
+                break
+        if changed:
+            continue
+        for pattern in _CORRECTION_PREFIX_PATTERNS:
+            new_text = re.sub(pattern, "", text).strip()
+            if new_text != text:
+                text = new_text
+                changed = True
+                break
+        if changed:
+            continue
         for prefix in _CONVERSATIONAL_PREFIXES:
             if text.startswith(prefix):
                 text = text[len(prefix):].strip()
@@ -115,6 +130,22 @@ def clean_query(raw: str) -> str:
     result = text.strip().rstrip("?.,!")
     log.info("Cleaned query: %r -> %r", raw[:50], result)
     return result
+
+
+def _snippet_count(result: str) -> int:
+    """Count non-empty web context lines for diagnostics."""
+    return sum(1 for line in result.splitlines() if line.strip())
+
+
+def _log_web_context(query: str, result: str, *, source: str) -> None:
+    """Log web context size without dumping snippet content."""
+    log.info(
+        "Web context ready: source=%s query=%r chars=%d snippets=%d",
+        source,
+        query[:80],
+        len(result),
+        _snippet_count(result),
+    )
 
 
 # ── Weather: wttr.in handler ──────────────────────────────────────────
@@ -230,7 +261,9 @@ def search_web(query: str) -> str:
     # Return cached result if still valid
     if cache_key in cache and _is_cache_valid(cache[cache_key]):
         log.info("Returning cached result for: %s", query[:50])
-        return cache[cache_key]["result"]
+        result = cache[cache_key]["result"]
+        _log_web_context(query, result, source="cache")
+        return result
 
     # Weather queries → wttr.in for structured data
     is_weather = any(kw in query.lower() for kw in _WEATHER_KEYWORDS)
@@ -254,6 +287,8 @@ def search_web(query: str) -> str:
 
     if not result or not result.strip():
         return "I searched but didn't find any relevant results, Chan."
+
+    _log_web_context(query, result, source="fetch")
 
     # Cache the result
     cache[cache_key] = {

--- a/tests/test_brain_voice_policy.py
+++ b/tests/test_brain_voice_policy.py
@@ -6,6 +6,8 @@ Voice response length policy tests.
 
 from __future__ import annotations
 
+import pytest
+
 import core.brain as brain
 
 
@@ -39,3 +41,31 @@ def test_voice_policy_trims_long_single_sentence(monkeypatch) -> None:
 
     assert out.endswith(".")
     assert len(out) <= 45
+
+
+def test_complete_sentence_guard_appends_safe_missing_period() -> None:
+    out = brain._ensure_complete_sentence(
+        "Hey Chan, you've got your project notes",
+        source="test",
+    )
+
+    assert out == "Hey Chan, you've got your project notes."
+
+
+def test_complete_sentence_guard_rejects_truncated_external_access() -> None:
+    with pytest.raises(brain.IncompleteModelResponseError):
+        brain._ensure_complete_sentence(
+            "Chan, I still don't have access to external",
+            source="test",
+            strict=True,
+        )
+
+
+def test_complete_sentence_guard_uses_fallback_when_not_strict() -> None:
+    out = brain._ensure_complete_sentence(
+        "Chan, I couldn't find the market capitalization for",
+        source="test",
+        fallback_message="Fallback response.",
+    )
+
+    assert out == "Fallback response."

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -1,0 +1,27 @@
+"""
+tests.test_web_search
+---------------------
+Web search query-cleaning regression tests.
+"""
+
+from __future__ import annotations
+
+from core.web_search import clean_query
+
+
+def test_clean_query_strips_correction_prefix_for_finance_news() -> None:
+    out = clean_query("No, how did Ryan Cohen interview go today?")
+
+    assert out == "how did ryan cohen interview go today"
+
+
+def test_clean_query_strips_chained_assistant_and_correction_prefixes() -> None:
+    out = clean_query("Aria, actually, I meant look up Ryan Cohen interview today")
+
+    assert out == "ryan cohen interview today"
+
+
+def test_clean_query_keeps_plain_negative_query_content() -> None:
+    out = clean_query("no news about GameStop today")
+
+    assert out == "news about gamestop today"


### PR DESCRIPTION
## Summary
- reject obviously incomplete Tier 2 model responses instead of appending punctuation and speaking broken fragments
- fall back from incomplete Gemini web responses to the Ollama Tier 2 fallback path
- add safer fallback wording for incomplete vision/Ollama responses
- strip correction prefixes such as 'no', 'actually', and 'I meant' from web queries
- log web context source, character count, and snippet count for future aria.log reviews

## Validation
- python -m pytest tests\\test_brain_voice_policy.py tests\\test_web_search.py tests\\test_router.py -q
- python -m pytest -q
- python tools\\run_validation.py --skip-pytest

## Next branch
Stage 2 self-logging should convert runtime turn data, warnings, slow turns, routing failures, and user corrections into structured session review records for later ML/training workflows.